### PR TITLE
Implement Slice 3: GitHub Data Fetching

### DIFF
--- a/src/ingestion/pipeline.ts
+++ b/src/ingestion/pipeline.ts
@@ -66,7 +66,10 @@ export class IngestionPipeline implements vscode.Disposable {
       this.syncStore.startSync(syncId, dataSourceId, commitSha);
 
       // Fetch file tree
-      const tree = await this.fetcher.getTree(ds.owner, ds.repo, commitSha);
+      const { entries: tree, truncated } = await this.fetcher.getTree(ds.owner, ds.repo, commitSha);
+      if (truncated) {
+        this.logger.warn(`File tree for ${ds.owner}/${ds.repo} was truncated by GitHub API`);
+      }
 
       // Filter files
       const filter = new FileFilter(

--- a/src/sources/github/githubFetcher.ts
+++ b/src/sources/github/githubFetcher.ts
@@ -1,35 +1,81 @@
 import { FetchedFile, FileTreeEntry } from '../dataSource';
+import { githubHeaders } from './githubResolver';
 
 const GITHUB_API = 'https://api.github.com';
 
+/**
+ * Maximum file size (in bytes) to fetch. Files larger than this are
+ * assumed to be binaries or generated artifacts and are skipped.
+ */
+const MAX_FILE_SIZE = 1_000_000; // 1 MB
+
+/**
+ * File extensions that are always skipped (binary / non-textual).
+ */
+const BINARY_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.ico', '.bmp', '.webp', '.svg',
+  '.woff', '.woff2', '.ttf', '.eot', '.otf',
+  '.zip', '.tar', '.gz', '.bz2', '.xz', '.7z', '.rar',
+  '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx',
+  '.exe', '.dll', '.so', '.dylib', '.o', '.a', '.lib',
+  '.wasm', '.pyc', '.class', '.jar',
+  '.mp3', '.mp4', '.avi', '.mov', '.wav', '.flac',
+  '.sqlite', '.db',
+]);
+
+export interface RateLimitInfo {
+  remaining: number;
+  resetAt: Date;
+}
+
 export class GitHubFetcher {
+  private rateLimitRemaining: number = Infinity;
+  private rateLimitResetAt: Date = new Date(0);
+
   constructor(private readonly getToken: () => Promise<string>) {}
 
-  async getTree(owner: string, repo: string, sha: string): Promise<FileTreeEntry[]> {
+  getRateLimitInfo(): RateLimitInfo {
+    return {
+      remaining: this.rateLimitRemaining,
+      resetAt: this.rateLimitResetAt,
+    };
+  }
+
+  async getTree(owner: string, repo: string, sha: string): Promise<{ entries: FileTreeEntry[]; truncated: boolean }> {
     const token = await this.getToken();
     const res = await fetch(
-      `${GITHUB_API}/repos/${owner}/${repo}/git/trees/${sha}?recursive=1`,
-      { headers: this.headers(token) },
+      `${GITHUB_API}/repos/${enc(owner)}/${enc(repo)}/git/trees/${enc(sha)}?recursive=1`,
+      { headers: githubHeaders(token) },
     );
+    this.updateRateLimit(res);
+
     if (!res.ok) {
-      throw new Error(`GitHub API error ${res.status}: ${res.statusText}`);
+      throw new Error(`GitHub Trees API error ${res.status}: ${res.statusText}`);
     }
+
     const data = (await res.json()) as { tree: FileTreeEntry[]; truncated: boolean };
-    if (data.truncated) {
-      // Tree is too large — logged but not fatal for v1
-    }
-    return data.tree.filter((entry) => entry.type === 'blob');
+
+    const blobs = data.tree.filter((entry) => entry.type === 'blob');
+    return { entries: blobs, truncated: data.truncated };
   }
 
   async getBlob(owner: string, repo: string, sha: string): Promise<string> {
     const token = await this.getToken();
     const res = await fetch(
-      `${GITHUB_API}/repos/${owner}/${repo}/git/blobs/${sha}`,
-      { headers: { ...this.headers(token), Accept: 'application/vnd.github.raw+json' } },
+      `${GITHUB_API}/repos/${enc(owner)}/${enc(repo)}/git/blobs/${enc(sha)}`,
+      {
+        headers: {
+          ...githubHeaders(token),
+          Accept: 'application/vnd.github.raw+json',
+        },
+      },
     );
+    this.updateRateLimit(res);
+
     if (!res.ok) {
-      throw new Error(`GitHub API error ${res.status}: ${res.statusText}`);
+      throw new Error(`GitHub Blobs API error ${res.status}: ${res.statusText}`);
     }
+
     return res.text();
   }
 
@@ -39,23 +85,39 @@ export class GitHubFetcher {
     entries: FileTreeEntry[],
     concurrency: number = 5,
   ): Promise<FetchedFile[]> {
+    // Pre-filter: skip binary extensions and oversized files
+    const eligible = entries.filter((entry) => {
+      if (entry.size > MAX_FILE_SIZE) return false;
+      const ext = extname(entry.path);
+      return !BINARY_EXTENSIONS.has(ext);
+    });
+
     const results: FetchedFile[] = [];
-    const queue = [...entries];
+    const queue = [...eligible];
 
     const worker = async (): Promise<void> => {
       while (queue.length > 0) {
+        // Check rate limit before each request
+        await this.waitForRateLimit();
+
         const entry = queue.shift()!;
-        const content = await this.getBlob(owner, repo, entry.sha);
-        results.push({
-          path: entry.path,
-          content,
-          sha: entry.sha,
-          size: entry.size,
-        });
+        try {
+          const content = await this.getBlob(owner, repo, entry.sha);
+          results.push({
+            path: entry.path,
+            content,
+            sha: entry.sha,
+            size: entry.size,
+          });
+        } catch {
+          // Skip files that fail to fetch (permissions, encoding issues)
+          // The caller handles missing files gracefully
+        }
       }
     };
 
-    const workers = Array.from({ length: Math.min(concurrency, queue.length) }, () => worker());
+    const workerCount = Math.min(concurrency, queue.length);
+    const workers = Array.from({ length: workerCount }, () => worker());
     await Promise.all(workers);
     return results;
   }
@@ -63,21 +125,55 @@ export class GitHubFetcher {
   async getBranchSha(owner: string, repo: string, branch: string): Promise<string> {
     const token = await this.getToken();
     const res = await fetch(
-      `${GITHUB_API}/repos/${owner}/${repo}/branches/${encodeURIComponent(branch)}`,
-      { headers: this.headers(token) },
+      `${GITHUB_API}/repos/${enc(owner)}/${enc(repo)}/branches/${enc(branch)}`,
+      { headers: githubHeaders(token) },
     );
+    this.updateRateLimit(res);
+
     if (!res.ok) {
+      if (res.status === 404) {
+        throw new Error(`Branch "${branch}" not found in ${owner}/${repo}.`);
+      }
       throw new Error(`GitHub API error ${res.status}: ${res.statusText}`);
     }
     const data = (await res.json()) as { commit: { sha: string } };
     return data.commit.sha;
   }
 
-  private headers(token: string): Record<string, string> {
-    return {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28',
-    };
+  private updateRateLimit(res: Response): void {
+    const remaining = res.headers.get('X-RateLimit-Remaining');
+    const reset = res.headers.get('X-RateLimit-Reset');
+
+    if (remaining !== null) {
+      this.rateLimitRemaining = parseInt(remaining, 10);
+    }
+    if (reset !== null) {
+      this.rateLimitResetAt = new Date(parseInt(reset, 10) * 1000);
+    }
   }
+
+  private async waitForRateLimit(): Promise<void> {
+    if (this.rateLimitRemaining > 10) return;
+
+    const waitMs = this.rateLimitResetAt.getTime() - Date.now();
+    if (waitMs > 0 && waitMs < 120_000) {
+      // Wait up to 2 minutes for rate limit reset
+      await new Promise((resolve) => setTimeout(resolve, waitMs + 1000));
+    } else if (this.rateLimitRemaining <= 0) {
+      throw new Error(
+        'GitHub API rate limit exceeded. Try again after ' +
+        this.rateLimitResetAt.toISOString(),
+      );
+    }
+  }
+}
+
+function enc(s: string): string {
+  return encodeURIComponent(s);
+}
+
+function extname(filePath: string): string {
+  const dot = filePath.lastIndexOf('.');
+  if (dot === -1 || dot === filePath.length - 1) return '';
+  return filePath.slice(dot).toLowerCase();
 }

--- a/src/sources/github/githubResolver.ts
+++ b/src/sources/github/githubResolver.ts
@@ -2,12 +2,63 @@ import { RepoMetadata } from '../dataSource';
 
 const GITHUB_API = 'https://api.github.com';
 
-const REPO_URL_PATTERN = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/;
+/**
+ * Patterns that match GitHub HTTPS URLs.
+ * Captures owner and repo from paths like:
+ *   https://github.com/owner/repo
+ *   https://github.com/owner/repo/
+ *   https://github.com/owner/repo.git
+ *   https://github.com/owner/repo/tree/main
+ */
+const HTTPS_REPO_PATTERN = /^https?:\/\/github\.com\/([^/]+)\/([^/.]+?)(?:\.git)?(?:\/.*)?$/;
 
-export function parseRepoUrl(url: string): { owner: string; repo: string } | null {
-  const match = url.match(REPO_URL_PATTERN);
-  if (!match) return null;
-  return { owner: match[1], repo: match[2].replace(/\.git$/, '') };
+/** SSH URLs like git@github.com:owner/repo.git */
+const SSH_REPO_PATTERN = /^git@github\.com:([^/]+)\/([^/.]+?)(?:\.git)?$/;
+
+/** GitHub Enterprise URLs (not supported in v1) */
+const ENTERPRISE_PATTERN = /^https?:\/\/(?!github\.com\b)[^/]+\/([^/]+)\/([^/]+)/;
+
+export interface ParseRepoUrlResult {
+  owner: string;
+  repo: string;
+}
+
+export interface ParseRepoUrlError {
+  error: string;
+}
+
+export function parseRepoUrl(url: string): ParseRepoUrlResult | ParseRepoUrlError {
+  const trimmed = url.trim();
+
+  if (!trimmed) {
+    return { error: 'URL is empty' };
+  }
+
+  // Check SSH URLs — supported for parsing but we inform users to use HTTPS
+  const sshMatch = trimmed.match(SSH_REPO_PATTERN);
+  if (sshMatch) {
+    return { owner: sshMatch[1], repo: sshMatch[2] };
+  }
+
+  // Check GitHub Enterprise URLs
+  if (ENTERPRISE_PATTERN.test(trimmed) && !trimmed.includes('github.com')) {
+    return { error: 'GitHub Enterprise URLs are not supported in v1. Use a github.com URL.' };
+  }
+
+  // Standard HTTPS URL
+  const httpsMatch = trimmed.match(HTTPS_REPO_PATTERN);
+  if (httpsMatch) {
+    return { owner: httpsMatch[1], repo: httpsMatch[2] };
+  }
+
+  return { error: 'Enter a valid GitHub repository URL (e.g. https://github.com/owner/repo)' };
+}
+
+/**
+ * Type guard: returns true if the result is a successful parse.
+ */
+export function isRepoUrlResult(result: ParseRepoUrlResult | ParseRepoUrlError): result is ParseRepoUrlResult {
+  return 'owner' in result;
 }
 
 export class GitHubResolver {
@@ -15,14 +66,13 @@ export class GitHubResolver {
 
   async resolve(owner: string, repo: string): Promise<RepoMetadata> {
     const token = await this.getToken();
-    const res = await fetch(`${GITHUB_API}/repos/${owner}/${repo}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
+    const res = await fetch(`${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`, {
+      headers: githubHeaders(token),
     });
     if (!res.ok) {
+      if (res.status === 404) {
+        throw new Error(`Repository ${owner}/${repo} not found. Check the URL and your access permissions.`);
+      }
       throw new Error(`GitHub API error ${res.status}: ${res.statusText}`);
     }
     const data = (await res.json()) as {
@@ -40,4 +90,12 @@ export class GitHubResolver {
       private: data.private,
     };
   }
+}
+
+export function githubHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
 }

--- a/src/sources/github/repoBrowser.ts
+++ b/src/sources/github/repoBrowser.ts
@@ -1,3 +1,5 @@
+import { githubHeaders } from './githubResolver';
+
 const GITHUB_API = 'https://api.github.com';
 
 export interface RepoSearchResult {
@@ -16,67 +18,56 @@ export class RepoBrowser {
     const token = await this.getToken();
     const res = await fetch(
       `${GITHUB_API}/user/repos?sort=updated&per_page=${perPage}&page=${page}`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github+json',
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-      },
+      { headers: githubHeaders(token) },
     );
     if (!res.ok) {
       throw new Error(`GitHub API error ${res.status}: ${res.statusText}`);
     }
-    const data = (await res.json()) as Array<{
-      owner: { login: string };
-      name: string;
-      full_name: string;
-      description: string | null;
-      private: boolean;
-      html_url: string;
-    }>;
-    return data.map((r) => ({
-      owner: r.owner.login,
-      repo: r.name,
-      fullName: r.full_name,
-      description: r.description,
-      private: r.private,
-      url: r.html_url,
-    }));
+    return (await res.json() as RepoListItem[]).map(mapRepoItem);
+  }
+
+  async listStarredRepos(page: number = 1, perPage: number = 30): Promise<RepoSearchResult[]> {
+    const token = await this.getToken();
+    const res = await fetch(
+      `${GITHUB_API}/user/starred?sort=updated&per_page=${perPage}&page=${page}`,
+      { headers: githubHeaders(token) },
+    );
+    if (!res.ok) {
+      throw new Error(`GitHub API error ${res.status}: ${res.statusText}`);
+    }
+    return (await res.json() as RepoListItem[]).map(mapRepoItem);
   }
 
   async searchRepos(query: string, page: number = 1): Promise<RepoSearchResult[]> {
     const token = await this.getToken();
     const res = await fetch(
       `${GITHUB_API}/search/repositories?q=${encodeURIComponent(query)}&per_page=20&page=${page}`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github+json',
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-      },
+      { headers: githubHeaders(token) },
     );
     if (!res.ok) {
       throw new Error(`GitHub API error ${res.status}: ${res.statusText}`);
     }
-    const data = (await res.json()) as {
-      items: Array<{
-        owner: { login: string };
-        name: string;
-        full_name: string;
-        description: string | null;
-        private: boolean;
-        html_url: string;
-      }>;
-    };
-    return data.items.map((r) => ({
-      owner: r.owner.login,
-      repo: r.name,
-      fullName: r.full_name,
-      description: r.description,
-      private: r.private,
-      url: r.html_url,
-    }));
+    const data = (await res.json()) as { items: RepoListItem[] };
+    return data.items.map(mapRepoItem);
   }
+}
+
+interface RepoListItem {
+  owner: { login: string };
+  name: string;
+  full_name: string;
+  description: string | null;
+  private: boolean;
+  html_url: string;
+}
+
+function mapRepoItem(r: RepoListItem): RepoSearchResult {
+  return {
+    owner: r.owner.login,
+    repo: r.name,
+    fullName: r.full_name,
+    description: r.description,
+    private: r.private,
+    url: r.html_url,
+  };
 }

--- a/src/ui/wizard/addRepoWizard.ts
+++ b/src/ui/wizard/addRepoWizard.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { parseRepoUrl, GitHubResolver } from '../../sources/github/githubResolver';
+import { parseRepoUrl, isRepoUrlResult, GitHubResolver } from '../../sources/github/githubResolver';
 import { RepoBrowser } from '../../sources/github/repoBrowser';
 import { DataSourceManager, AddDataSourceOptions } from '../../sources/dataSourceManager';
 import { DEFAULT_EXCLUDE_PATTERNS, ToolConfig } from '../../config/configSchema';
@@ -114,11 +114,15 @@ export class AddRepoWizard {
       const url = await vscode.window.showInputBox({
         prompt: 'GitHub repository URL',
         placeHolder: 'https://github.com/owner/repo',
-        validateInput: (v) => (parseRepoUrl(v) ? null : 'Enter a valid GitHub repo URL'),
+        validateInput: (v) => {
+          const result = parseRepoUrl(v);
+          return isRepoUrlResult(result) ? null : result.error;
+        },
         ignoreFocusOut: true,
       });
       if (!url) return undefined;
-      return parseRepoUrl(url) ?? undefined;
+      const result = parseRepoUrl(url);
+      return isRepoUrlResult(result) ? result : undefined;
     }
 
     // Browse repos

--- a/test/unit/sources/github/githubFetcher.test.ts
+++ b/test/unit/sources/github/githubFetcher.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { GitHubFetcher } from '../../../../src/sources/github/githubFetcher';
+
+function makeFetcher() {
+  return new GitHubFetcher(async () => 'test-token');
+}
+
+function mockResponse(data: object, status = 200, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: new Headers({
+      'X-RateLimit-Remaining': '4999',
+      'X-RateLimit-Reset': String(Math.floor(Date.now() / 1000) + 3600),
+      ...headers,
+    }),
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  };
+}
+
+describe('GitHubFetcher', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('getTree', () => {
+    it('returns blob entries from tree', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse({
+          tree: [
+            { path: 'src/index.ts', sha: 'aaa', size: 100, type: 'blob' },
+            { path: 'src', sha: 'bbb', size: 0, type: 'tree' },
+            { path: 'src/util.ts', sha: 'ccc', size: 200, type: 'blob' },
+          ],
+          truncated: false,
+        }),
+      );
+
+      const fetcher = makeFetcher();
+      const { entries, truncated } = await fetcher.getTree('owner', 'repo', 'abc123');
+
+      expect(entries).toHaveLength(2);
+      expect(entries[0].path).toBe('src/index.ts');
+      expect(entries[1].path).toBe('src/util.ts');
+      expect(truncated).toBe(false);
+    });
+
+    it('reports truncated tree', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse({ tree: [], truncated: true }),
+      );
+
+      const fetcher = makeFetcher();
+      const { truncated } = await fetcher.getTree('owner', 'repo', 'abc');
+      expect(truncated).toBe(true);
+    });
+
+    it('throws on API error', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse({}, 403, {}),
+      );
+
+      const fetcher = makeFetcher();
+      await expect(fetcher.getTree('owner', 'repo', 'abc')).rejects.toThrow('403');
+    });
+  });
+
+  describe('getBlob', () => {
+    it('returns file content as text', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'X-RateLimit-Remaining': '100', 'X-RateLimit-Reset': '9999999999' }),
+        text: async () => 'const x = 1;',
+      });
+
+      const fetcher = makeFetcher();
+      const content = await fetcher.getBlob('owner', 'repo', 'sha123');
+      expect(content).toBe('const x = 1;');
+    });
+
+    it('sends raw content accept header', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'X-RateLimit-Remaining': '100', 'X-RateLimit-Reset': '9999999999' }),
+        text: async () => '',
+      });
+      globalThis.fetch = fetchMock;
+
+      const fetcher = makeFetcher();
+      await fetcher.getBlob('owner', 'repo', 'sha');
+
+      expect(fetchMock.mock.calls[0][1].headers.Accept).toBe(
+        'application/vnd.github.raw+json',
+      );
+    });
+  });
+
+  describe('getBranchSha', () => {
+    it('returns commit SHA for branch', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse({ commit: { sha: 'deadbeef' } }),
+      );
+
+      const fetcher = makeFetcher();
+      const sha = await fetcher.getBranchSha('owner', 'repo', 'main');
+      expect(sha).toBe('deadbeef');
+    });
+
+    it('throws descriptive error on 404', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse({}, 404),
+      );
+
+      const fetcher = makeFetcher();
+      await expect(
+        fetcher.getBranchSha('owner', 'repo', 'nonexistent'),
+      ).rejects.toThrow('Branch "nonexistent" not found');
+    });
+  });
+
+  describe('fetchFiles', () => {
+    it('fetches eligible files concurrently', async () => {
+      const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+        if (url.includes('/trees/')) {
+          return mockResponse({ tree: [], truncated: false });
+        }
+        // Blob requests
+        const sha = url.split('/blobs/')[1];
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'X-RateLimit-Remaining': '100', 'X-RateLimit-Reset': '9999999999' }),
+          text: async () => `content-of-${sha}`,
+        };
+      });
+      globalThis.fetch = fetchMock;
+
+      const fetcher = makeFetcher();
+      const entries = [
+        { path: 'a.ts', sha: 'aaa', size: 100, type: 'blob' as const },
+        { path: 'b.ts', sha: 'bbb', size: 200, type: 'blob' as const },
+      ];
+      const files = await fetcher.fetchFiles('owner', 'repo', entries, 2);
+
+      expect(files).toHaveLength(2);
+      expect(files.find((f) => f.path === 'a.ts')?.content).toBe('content-of-aaa');
+      expect(files.find((f) => f.path === 'b.ts')?.content).toBe('content-of-bbb');
+    });
+
+    it('skips binary file extensions', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'X-RateLimit-Remaining': '100', 'X-RateLimit-Reset': '9999999999' }),
+        text: async () => 'content',
+      });
+
+      const fetcher = makeFetcher();
+      const entries = [
+        { path: 'image.png', sha: 'aaa', size: 100, type: 'blob' as const },
+        { path: 'font.woff2', sha: 'bbb', size: 200, type: 'blob' as const },
+        { path: 'code.ts', sha: 'ccc', size: 50, type: 'blob' as const },
+      ];
+      const files = await fetcher.fetchFiles('owner', 'repo', entries, 2);
+
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe('code.ts');
+    });
+
+    it('skips files larger than 1MB', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'X-RateLimit-Remaining': '100', 'X-RateLimit-Reset': '9999999999' }),
+        text: async () => 'content',
+      });
+
+      const fetcher = makeFetcher();
+      const entries = [
+        { path: 'huge.ts', sha: 'aaa', size: 2_000_000, type: 'blob' as const },
+        { path: 'small.ts', sha: 'bbb', size: 500, type: 'blob' as const },
+      ];
+      const files = await fetcher.fetchFiles('owner', 'repo', entries, 2);
+
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe('small.ts');
+    });
+
+    it('skips files that fail to fetch without throwing', async () => {
+      let callCount = 0;
+      globalThis.fetch = vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            ok: false,
+            status: 403,
+            statusText: 'Forbidden',
+            headers: new Headers({ 'X-RateLimit-Remaining': '100', 'X-RateLimit-Reset': '9999999999' }),
+            text: async () => 'forbidden',
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'X-RateLimit-Remaining': '100', 'X-RateLimit-Reset': '9999999999' }),
+          text: async () => 'good content',
+        };
+      });
+
+      const fetcher = makeFetcher();
+      const entries = [
+        { path: 'forbidden.ts', sha: 'aaa', size: 100, type: 'blob' as const },
+        { path: 'allowed.ts', sha: 'bbb', size: 100, type: 'blob' as const },
+      ];
+      const files = await fetcher.fetchFiles('owner', 'repo', entries, 1);
+
+      // Should only get the file that succeeded
+      expect(files).toHaveLength(1);
+      expect(files[0].path).toBe('allowed.ts');
+    });
+  });
+
+  describe('rate limit tracking', () => {
+    it('tracks rate limit from response headers', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(
+          { commit: { sha: 'abc' } },
+          200,
+          { 'X-RateLimit-Remaining': '42', 'X-RateLimit-Reset': '1700000000' },
+        ),
+      );
+
+      const fetcher = makeFetcher();
+      await fetcher.getBranchSha('owner', 'repo', 'main');
+
+      const info = fetcher.getRateLimitInfo();
+      expect(info.remaining).toBe(42);
+      expect(info.resetAt.getTime()).toBe(1700000000 * 1000);
+    });
+
+    it('throws when rate limit is exhausted', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(
+          { tree: [], truncated: false },
+          200,
+          {
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': String(Math.floor(Date.now() / 1000) + 7200),
+          },
+        ),
+      );
+
+      const fetcher = makeFetcher();
+      // First call succeeds but sets remaining to 0
+      await fetcher.getTree('owner', 'repo', 'sha');
+
+      // fetchFiles should throw because rate limit is exhausted
+      const entries = [{ path: 'a.ts', sha: 'aaa', size: 10, type: 'blob' as const }];
+      await expect(
+        fetcher.fetchFiles('owner', 'repo', entries, 1),
+      ).rejects.toThrow('rate limit exceeded');
+    });
+  });
+});

--- a/test/unit/sources/github/githubResolver.test.ts
+++ b/test/unit/sources/github/githubResolver.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { parseRepoUrl, isRepoUrlResult, GitHubResolver } from '../../../../src/sources/github/githubResolver';
+
+describe('parseRepoUrl', () => {
+  it('parses standard HTTPS URL', () => {
+    const result = parseRepoUrl('https://github.com/microsoft/vscode');
+    expect(isRepoUrlResult(result)).toBe(true);
+    if (isRepoUrlResult(result)) {
+      expect(result.owner).toBe('microsoft');
+      expect(result.repo).toBe('vscode');
+    }
+  });
+
+  it('parses URL with trailing slash', () => {
+    const result = parseRepoUrl('https://github.com/owner/repo/');
+    expect(isRepoUrlResult(result)).toBe(true);
+    if (isRepoUrlResult(result)) {
+      expect(result.owner).toBe('owner');
+      expect(result.repo).toBe('repo');
+    }
+  });
+
+  it('parses URL with .git suffix', () => {
+    const result = parseRepoUrl('https://github.com/owner/repo.git');
+    expect(isRepoUrlResult(result)).toBe(true);
+    if (isRepoUrlResult(result)) {
+      expect(result.owner).toBe('owner');
+      expect(result.repo).toBe('repo');
+    }
+  });
+
+  it('parses URL with tree/branch path', () => {
+    const result = parseRepoUrl('https://github.com/owner/repo/tree/main');
+    expect(isRepoUrlResult(result)).toBe(true);
+    if (isRepoUrlResult(result)) {
+      expect(result.owner).toBe('owner');
+      expect(result.repo).toBe('repo');
+    }
+  });
+
+  it('parses URL with blob/file path', () => {
+    const result = parseRepoUrl('https://github.com/owner/repo/blob/main/src/index.ts');
+    expect(isRepoUrlResult(result)).toBe(true);
+    if (isRepoUrlResult(result)) {
+      expect(result.owner).toBe('owner');
+      expect(result.repo).toBe('repo');
+    }
+  });
+
+  it('parses HTTP URL (no TLS)', () => {
+    const result = parseRepoUrl('http://github.com/owner/repo');
+    expect(isRepoUrlResult(result)).toBe(true);
+  });
+
+  it('parses SSH URL', () => {
+    const result = parseRepoUrl('git@github.com:owner/repo.git');
+    expect(isRepoUrlResult(result)).toBe(true);
+    if (isRepoUrlResult(result)) {
+      expect(result.owner).toBe('owner');
+      expect(result.repo).toBe('repo');
+    }
+  });
+
+  it('parses SSH URL without .git', () => {
+    const result = parseRepoUrl('git@github.com:owner/repo');
+    expect(isRepoUrlResult(result)).toBe(true);
+    if (isRepoUrlResult(result)) {
+      expect(result.owner).toBe('owner');
+      expect(result.repo).toBe('repo');
+    }
+  });
+
+  it('rejects GitHub Enterprise URLs', () => {
+    const result = parseRepoUrl('https://github.mycompany.com/owner/repo');
+    expect(isRepoUrlResult(result)).toBe(false);
+    if (!isRepoUrlResult(result)) {
+      expect(result.error).toContain('Enterprise');
+    }
+  });
+
+  it('rejects empty string', () => {
+    const result = parseRepoUrl('');
+    expect(isRepoUrlResult(result)).toBe(false);
+    if (!isRepoUrlResult(result)) {
+      expect(result.error).toContain('empty');
+    }
+  });
+
+  it('rejects whitespace-only string', () => {
+    const result = parseRepoUrl('   ');
+    expect(isRepoUrlResult(result)).toBe(false);
+  });
+
+  it('rejects non-URL strings', () => {
+    const result = parseRepoUrl('not a url');
+    expect(isRepoUrlResult(result)).toBe(false);
+  });
+
+  it('rejects URL with only owner, no repo', () => {
+    const result = parseRepoUrl('https://github.com/owner');
+    expect(isRepoUrlResult(result)).toBe(false);
+  });
+
+  it('trims whitespace', () => {
+    const result = parseRepoUrl('  https://github.com/owner/repo  ');
+    expect(isRepoUrlResult(result)).toBe(true);
+  });
+
+  it('handles hyphens and underscores in names', () => {
+    const result = parseRepoUrl('https://github.com/my-org/my_repo-v2');
+    expect(isRepoUrlResult(result)).toBe(true);
+    if (isRepoUrlResult(result)) {
+      expect(result.owner).toBe('my-org');
+      expect(result.repo).toBe('my_repo-v2');
+    }
+  });
+});
+
+describe('GitHubResolver', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('resolves repo metadata', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        owner: { login: 'microsoft' },
+        name: 'vscode',
+        default_branch: 'main',
+        description: 'Visual Studio Code',
+        private: false,
+      }),
+    });
+
+    const resolver = new GitHubResolver(async () => 'token');
+    const meta = await resolver.resolve('microsoft', 'vscode');
+
+    expect(meta.owner).toBe('microsoft');
+    expect(meta.repo).toBe('vscode');
+    expect(meta.defaultBranch).toBe('main');
+    expect(meta.description).toBe('Visual Studio Code');
+    expect(meta.private).toBe(false);
+  });
+
+  it('throws descriptive error on 404', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+
+    const resolver = new GitHubResolver(async () => 'token');
+    await expect(resolver.resolve('owner', 'nonexistent')).rejects.toThrow(
+      'not found',
+    );
+  });
+
+  it('sends correct auth headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        owner: { login: 'o' },
+        name: 'r',
+        default_branch: 'main',
+        description: null,
+        private: true,
+      }),
+    });
+    globalThis.fetch = fetchMock;
+
+    const resolver = new GitHubResolver(async () => 'my-secret-token');
+    await resolver.resolve('o', 'r');
+
+    const headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers.Authorization).toBe('Bearer my-secret-token');
+    expect(headers['X-GitHub-Api-Version']).toBe('2022-11-28');
+  });
+});

--- a/test/unit/sources/github/repoBrowser.test.ts
+++ b/test/unit/sources/github/repoBrowser.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RepoBrowser } from '../../../../src/sources/github/repoBrowser';
+
+function mockResponse(data: object, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  };
+}
+
+const SAMPLE_REPOS = [
+  {
+    owner: { login: 'alice' },
+    name: 'project-a',
+    full_name: 'alice/project-a',
+    description: 'First project',
+    private: false,
+    html_url: 'https://github.com/alice/project-a',
+  },
+  {
+    owner: { login: 'alice' },
+    name: 'project-b',
+    full_name: 'alice/project-b',
+    description: null,
+    private: true,
+    html_url: 'https://github.com/alice/project-b',
+  },
+];
+
+describe('RepoBrowser', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('lists user repos', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(SAMPLE_REPOS));
+
+    const browser = new RepoBrowser(async () => 'token');
+    const repos = await browser.listUserRepos();
+
+    expect(repos).toHaveLength(2);
+    expect(repos[0].owner).toBe('alice');
+    expect(repos[0].repo).toBe('project-a');
+    expect(repos[0].fullName).toBe('alice/project-a');
+    expect(repos[0].description).toBe('First project');
+    expect(repos[0].private).toBe(false);
+    expect(repos[1].private).toBe(true);
+    expect(repos[1].description).toBeNull();
+  });
+
+  it('passes pagination params', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse([]));
+    globalThis.fetch = fetchMock;
+
+    const browser = new RepoBrowser(async () => 'token');
+    await browser.listUserRepos(2, 10);
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('page=2');
+    expect(url).toContain('per_page=10');
+  });
+
+  it('searches repos', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({ items: SAMPLE_REPOS }),
+    );
+
+    const browser = new RepoBrowser(async () => 'token');
+    const repos = await browser.searchRepos('typescript');
+
+    expect(repos).toHaveLength(2);
+  });
+
+  it('encodes search query', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ items: [] }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const browser = new RepoBrowser(async () => 'token');
+    await browser.searchRepos('react hooks language:typescript');
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('q=react%20hooks%20language%3Atypescript');
+  });
+
+  it('lists starred repos', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(SAMPLE_REPOS));
+
+    const browser = new RepoBrowser(async () => 'token');
+    const repos = await browser.listStarredRepos();
+
+    expect(repos).toHaveLength(2);
+  });
+
+  it('throws on API error', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      mockResponse({}, 401),
+    );
+
+    const browser = new RepoBrowser(async () => 'bad-token');
+    await expect(browser.listUserRepos()).rejects.toThrow('401');
+  });
+});


### PR DESCRIPTION
- parseRepoUrl: handles HTTPS, SSH, .git suffix, trailing slash, /tree/branch paths, enterprise rejection, whitespace trimming. Returns typed result or error object.
- GitHubFetcher: rate limit tracking via X-RateLimit headers with automatic pause when approaching zero. Binary file skipping by extension (images, fonts, archives, executables) and size (>1MB). getTree returns { entries, truncated } for logging.
- GitHubResolver: descriptive 404 error for missing repos, URL encoding for owner/repo params.
- RepoBrowser: added listStarredRepos, extracted shared mapRepoItem.
- Pipeline: updated for new getTree return shape, logs truncation.
- Wizard: updated for new parseRepoUrl error object API.
- 37 new tests across 3 test files (75 total), zero type errors.

https://claude.ai/code/session_01SivoQnekKoktVbgMjSnAd7