### PR TITLE
Implement Slices 5 & 6: Retrieval, Tool Registration, Config Hardening

### DIFF
--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -8,32 +8,94 @@ import {
   createDefaultConfig,
 } from './configSchema';
 
+const DEBOUNCE_MS = 300;
+
 export class ConfigManager implements vscode.Disposable {
   private config: RepoLensConfig;
   private readonly configPath: string;
   private readonly _onDidChange = new vscode.EventEmitter<RepoLensConfig>();
   readonly onDidChange = this._onDidChange.event;
 
+  private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  private fileWatcher: vscode.FileSystemWatcher | undefined;
+  private suppressNextFileEvent = false;
+
   constructor(globalStorageUri: vscode.Uri) {
     this.configPath = path.join(globalStorageUri.fsPath, 'repolens.json');
     this.config = this.load();
+    this.setupFileWatcher();
   }
 
   private load(): RepoLensConfig {
     try {
       const raw = fs.readFileSync(this.configPath, 'utf-8');
       return JSON.parse(raw) as RepoLensConfig;
-    } catch {
+    } catch (err) {
+      // If the file exists but is corrupt, back it up
+      if (fs.existsSync(this.configPath)) {
+        const backupPath = this.configPath + '.bak';
+        try {
+          fs.copyFileSync(this.configPath, backupPath);
+        } catch {
+          // Best-effort backup
+        }
+      }
       return createDefaultConfig();
     }
   }
 
-  private save(): void {
+  private saveImmediate(): void {
     const dir = path.dirname(this.configPath);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
+    this.suppressNextFileEvent = true;
     fs.writeFileSync(this.configPath, JSON.stringify(this.config, null, 2));
+    this._onDidChange.fire(this.config);
+  }
+
+  private save(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      this.saveImmediate();
+    }, DEBOUNCE_MS);
+  }
+
+  /**
+   * Flush any pending debounced writes immediately.
+   */
+  flush(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+      this.saveImmediate();
+    }
+  }
+
+  private setupFileWatcher(): void {
+    try {
+      const pattern = new vscode.RelativePattern(
+        path.dirname(this.configPath),
+        path.basename(this.configPath),
+      );
+      this.fileWatcher = vscode.workspace.createFileSystemWatcher(pattern);
+      this.fileWatcher.onDidChange(() => this.onFileChanged());
+      this.fileWatcher.onDidCreate(() => this.onFileChanged());
+    } catch {
+      // File watcher may not be available in all environments
+    }
+  }
+
+  private onFileChanged(): void {
+    if (this.suppressNextFileEvent) {
+      this.suppressNextFileEvent = false;
+      return;
+    }
+    const reloaded = this.load();
+    this.config = reloaded;
     this._onDidChange.fire(this.config);
   }
 
@@ -102,6 +164,10 @@ export class ConfigManager implements vscode.Disposable {
   }
 
   dispose(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.fileWatcher?.dispose();
     this._onDidChange.dispose();
   }
 }

--- a/test/unit/config/configManager.test.ts
+++ b/test/unit/config/configManager.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// Mock vscode
+const changeListeners: Array<(e: any) => void> = [];
+const fileWatcherCallbacks: { change: Array<() => void>; create: Array<() => void> } = {
+  change: [],
+  create: [],
+};
+
+vi.mock('vscode', () => ({
+  Uri: {
+    file: (p: string) => ({ fsPath: p }),
+  },
+  EventEmitter: class {
+    private listeners: Array<(e: any) => void> = [];
+    event = (listener: (e: any) => void) => {
+      this.listeners.push(listener);
+      changeListeners.push(listener);
+      return { dispose: vi.fn() };
+    };
+    fire(data: any) {
+      this.listeners.forEach((l) => l(data));
+    }
+    dispose() {}
+  },
+  RelativePattern: class {
+    constructor(public base: string, public pattern: string) {}
+  },
+  workspace: {
+    createFileSystemWatcher: vi.fn().mockImplementation(() => ({
+      onDidChange: (cb: () => void) => {
+        fileWatcherCallbacks.change.push(cb);
+        return { dispose: vi.fn() };
+      },
+      onDidCreate: (cb: () => void) => {
+        fileWatcherCallbacks.create.push(cb);
+        return { dispose: vi.fn() };
+      },
+      dispose: vi.fn(),
+    })),
+  },
+}));
+
+import { ConfigManager } from '../../../src/config/configManager';
+import { createDefaultConfig, DataSourceConfig } from '../../../src/config/configSchema';
+
+describe('ConfigManager', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repolens-test-'));
+    changeListeners.length = 0;
+    fileWatcherCallbacks.change.length = 0;
+    fileWatcherCallbacks.create.length = 0;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeUri() {
+    return { fsPath: tmpDir } as any;
+  }
+
+  function writeConfig(config: any) {
+    fs.writeFileSync(path.join(tmpDir, 'repolens.json'), JSON.stringify(config, null, 2));
+  }
+
+  function readConfig() {
+    return JSON.parse(fs.readFileSync(path.join(tmpDir, 'repolens.json'), 'utf-8'));
+  }
+
+  it('returns default config when no file exists', () => {
+    const manager = new ConfigManager(makeUri());
+    const config = manager.getConfig();
+    expect(config.version).toBe(1);
+    expect(config.dataSources).toEqual([]);
+    expect(config.tools).toEqual([]);
+    manager.dispose();
+  });
+
+  it('loads existing config from disk', () => {
+    const existing = createDefaultConfig();
+    existing.dataSources.push({
+      id: 'ds-1',
+      repoUrl: 'https://github.com/test/repo',
+      owner: 'test',
+      repo: 'repo',
+      branch: 'main',
+      includePatterns: [],
+      excludePatterns: [],
+      syncSchedule: 'manual',
+      lastSyncedAt: null,
+      lastSyncCommitSha: null,
+      status: 'ready',
+    });
+    writeConfig(existing);
+
+    const manager = new ConfigManager(makeUri());
+    expect(manager.getDataSources()).toHaveLength(1);
+    expect(manager.getDataSource('ds-1')?.owner).toBe('test');
+    manager.dispose();
+  });
+
+  it('handles corrupt JSON by backing up and resetting to defaults', () => {
+    const configPath = path.join(tmpDir, 'repolens.json');
+    fs.writeFileSync(configPath, '{corrupt json!!!');
+
+    const manager = new ConfigManager(makeUri());
+    const config = manager.getConfig();
+
+    // Should have reset to defaults
+    expect(config.version).toBe(1);
+    expect(config.dataSources).toEqual([]);
+
+    // Backup should exist
+    expect(fs.existsSync(configPath + '.bak')).toBe(true);
+    expect(fs.readFileSync(configPath + '.bak', 'utf-8')).toBe('{corrupt json!!!');
+    manager.dispose();
+  });
+
+  it('add/update/remove data source round-trip', () => {
+    const manager = new ConfigManager(makeUri());
+
+    const ds: DataSourceConfig = {
+      id: 'ds-1',
+      repoUrl: 'https://github.com/test/repo',
+      owner: 'test',
+      repo: 'repo',
+      branch: 'main',
+      includePatterns: [],
+      excludePatterns: [],
+      syncSchedule: 'manual',
+      lastSyncedAt: null,
+      lastSyncCommitSha: null,
+      status: 'queued',
+    };
+
+    manager.addDataSource(ds);
+    manager.flush();
+    expect(manager.getDataSource('ds-1')).toBeDefined();
+
+    manager.updateDataSource('ds-1', { status: 'ready' });
+    manager.flush();
+    expect(manager.getDataSource('ds-1')?.status).toBe('ready');
+
+    manager.removeDataSource('ds-1');
+    manager.flush();
+    expect(manager.getDataSource('ds-1')).toBeUndefined();
+    manager.dispose();
+  });
+
+  it('add/update/remove tool round-trip', () => {
+    const manager = new ConfigManager(makeUri());
+
+    manager.addTool({ id: 't-1', name: 'my-tool', description: 'test', dataSourceIds: ['ds-1'] });
+    manager.flush();
+    expect(manager.getTool('t-1')).toBeDefined();
+
+    manager.updateTool('t-1', { description: 'updated' });
+    manager.flush();
+    expect(manager.getTool('t-1')?.description).toBe('updated');
+
+    manager.removeTool('t-1');
+    manager.flush();
+    expect(manager.getTool('t-1')).toBeUndefined();
+    manager.dispose();
+  });
+
+  it('removeDataSource cleans tool references', () => {
+    const manager = new ConfigManager(makeUri());
+
+    manager.addDataSource({
+      id: 'ds-1', repoUrl: '', owner: 'o', repo: 'r', branch: 'main',
+      includePatterns: [], excludePatterns: [], syncSchedule: 'manual',
+      lastSyncedAt: null, lastSyncCommitSha: null, status: 'ready',
+    });
+    manager.addTool({ id: 't-1', name: 'tool', description: '', dataSourceIds: ['ds-1', 'ds-2'] });
+    manager.flush();
+
+    manager.removeDataSource('ds-1');
+    manager.flush();
+
+    expect(manager.getTool('t-1')?.dataSourceIds).toEqual(['ds-2']);
+    manager.dispose();
+  });
+
+  it('fires onDidChange when config is saved', () => {
+    const manager = new ConfigManager(makeUri());
+    const listener = vi.fn();
+    manager.onDidChange(listener);
+
+    manager.addDataSource({
+      id: 'ds-1', repoUrl: '', owner: 'o', repo: 'r', branch: 'main',
+      includePatterns: [], excludePatterns: [], syncSchedule: 'manual',
+      lastSyncedAt: null, lastSyncCommitSha: null, status: 'ready',
+    });
+    manager.flush();
+
+    expect(listener).toHaveBeenCalled();
+    manager.dispose();
+  });
+
+  it('debounces rapid writes', async () => {
+    const manager = new ConfigManager(makeUri());
+
+    // Rapid updates
+    for (let i = 0; i < 10; i++) {
+      manager.addDataSource({
+        id: `ds-${i}`, repoUrl: '', owner: 'o', repo: `r${i}`, branch: 'main',
+        includePatterns: [], excludePatterns: [], syncSchedule: 'manual',
+        lastSyncedAt: null, lastSyncCommitSha: null, status: 'ready',
+      });
+    }
+
+    // File should not exist yet (debounced)
+    const configPath = path.join(tmpDir, 'repolens.json');
+    const existsBeforeFlush = fs.existsSync(configPath);
+
+    // Flush to write
+    manager.flush();
+
+    // Now file should exist with all 10 data sources
+    const saved = readConfig();
+    expect(saved.dataSources).toHaveLength(10);
+
+    manager.dispose();
+  });
+
+  it('persists config across save → reload', () => {
+    const manager1 = new ConfigManager(makeUri());
+    manager1.addDataSource({
+      id: 'ds-1', repoUrl: '', owner: 'acme', repo: 'widgets', branch: 'main',
+      includePatterns: ['**/*.ts'], excludePatterns: [], syncSchedule: 'daily',
+      lastSyncedAt: null, lastSyncCommitSha: null, status: 'ready',
+    });
+    manager1.flush();
+    manager1.dispose();
+
+    // Reload from disk
+    const manager2 = new ConfigManager(makeUri());
+    expect(manager2.getDataSource('ds-1')?.owner).toBe('acme');
+    expect(manager2.getDataSource('ds-1')?.includePatterns).toEqual(['**/*.ts']);
+    manager2.dispose();
+  });
+
+  it('reloads when external file change is detected', () => {
+    const manager = new ConfigManager(makeUri());
+    manager.flush(); // ensure initial write if needed
+
+    // Simulate external edit by writing directly and firing watcher
+    const updated = createDefaultConfig();
+    updated.dataSources.push({
+      id: 'ext-1', repoUrl: '', owner: 'ext', repo: 'repo', branch: 'main',
+      includePatterns: [], excludePatterns: [], syncSchedule: 'manual',
+      lastSyncedAt: null, lastSyncCommitSha: null, status: 'ready',
+    });
+    writeConfig(updated);
+
+    // Fire file watcher callback
+    fileWatcherCallbacks.change.forEach((cb) => cb());
+
+    expect(manager.getDataSource('ext-1')?.owner).toBe('ext');
+    manager.dispose();
+  });
+
+  it('getDefaultExcludePatterns returns configured patterns', () => {
+    const manager = new ConfigManager(makeUri());
+    const patterns = manager.getDefaultExcludePatterns();
+    expect(patterns).toContain('**/node_modules/**');
+    expect(patterns).toContain('**/dist/**');
+    manager.dispose();
+  });
+});

--- a/test/unit/retrieval/contextBuilder.test.ts
+++ b/test/unit/retrieval/contextBuilder.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { ContextBuilder } from '../../../src/retrieval/contextBuilder';
+import { RetrievalResult } from '../../../src/retrieval/retriever';
+import { DataSourceConfig } from '../../../src/config/configSchema';
+
+// Minimal mock for ConfigManager — only getDataSource is used by ContextBuilder
+function makeMockConfigManager(dataSources: DataSourceConfig[]) {
+  const dsMap = new Map(dataSources.map((ds) => [ds.id, ds]));
+  return {
+    getDataSource: (id: string) => dsMap.get(id),
+  } as any; // cast to ConfigManager — only getDataSource is called
+}
+
+function makeResult(overrides: Partial<RetrievalResult['chunk']> = {}, distance = 0.1): RetrievalResult {
+  return {
+    chunk: {
+      id: 'c1',
+      dataSourceId: 'ds-1',
+      filePath: 'src/index.ts',
+      startLine: 1,
+      endLine: 10,
+      content: 'const hello = "world";',
+      tokenCount: 5,
+      ...overrides,
+    },
+    distance,
+  };
+}
+
+describe('ContextBuilder', () => {
+  const ds: DataSourceConfig = {
+    id: 'ds-1',
+    repoUrl: 'https://github.com/acme/widgets',
+    owner: 'acme',
+    repo: 'widgets',
+    branch: 'main',
+    includePatterns: [],
+    excludePatterns: [],
+    syncSchedule: 'manual',
+    lastSyncedAt: null,
+    lastSyncCommitSha: null,
+    status: 'ready',
+  };
+
+  it('formats results with repo label, file path, and line range', () => {
+    const builder = new ContextBuilder(makeMockConfigManager([ds]));
+    const output = builder.format([makeResult()]);
+
+    expect(output).toContain('acme/widgets');
+    expect(output).toContain('src/index.ts');
+    expect(output).toContain('L1-L10');
+    expect(output).toContain('const hello = "world"');
+  });
+
+  it('returns "No relevant results" for empty results', () => {
+    const builder = new ContextBuilder(makeMockConfigManager([ds]));
+    const output = builder.format([]);
+
+    expect(output).toBe('No relevant results found.');
+  });
+
+  it('formats multiple results with numbered sections', () => {
+    const builder = new ContextBuilder(makeMockConfigManager([ds]));
+    const results = [
+      makeResult({ id: 'c1', filePath: 'a.ts', startLine: 1, endLine: 5 }),
+      makeResult({ id: 'c2', filePath: 'b.ts', startLine: 10, endLine: 20 }),
+    ];
+
+    const output = builder.format(results);
+    expect(output).toContain('Result 1');
+    expect(output).toContain('Result 2');
+    expect(output).toContain('a.ts');
+    expect(output).toContain('b.ts');
+  });
+
+  it('shows "unknown" for data sources not in config', () => {
+    const builder = new ContextBuilder(makeMockConfigManager([]));
+    const output = builder.format([makeResult({ dataSourceId: 'missing' })]);
+
+    expect(output).toContain('unknown');
+  });
+
+  it('wraps content in code blocks', () => {
+    const builder = new ContextBuilder(makeMockConfigManager([ds]));
+    const output = builder.format([makeResult()]);
+
+    expect(output).toContain('```');
+  });
+});

--- a/test/unit/retrieval/retriever.test.ts
+++ b/test/unit/retrieval/retriever.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { openDatabase } from '../../../src/storage/database';
+import { ChunkStore, ChunkRecord } from '../../../src/storage/chunkStore';
+import { EmbeddingStore } from '../../../src/storage/embeddingStore';
+import { DataSourceStore } from '../../../src/storage/dataSourceStore';
+import { Retriever, RetrievalResult } from '../../../src/retrieval/retriever';
+import { EmbeddingProvider } from '../../../src/embedding/embeddingProvider';
+import Database from 'better-sqlite3';
+
+const DIMS = 4;
+
+function makeProvider(embedResult: number[][]): EmbeddingProvider {
+  return {
+    id: 'test',
+    maxBatchSize: 100,
+    dimensions: DIMS,
+    embed: async (texts: string[]) => embedResult,
+    countTokens: (text: string) => Math.ceil(text.length / 4),
+  };
+}
+
+describe('Retriever', () => {
+  let db: Database.Database;
+  let chunkStore: ChunkStore;
+  let embeddingStore: EmbeddingStore;
+  let dsStore: DataSourceStore;
+  let retriever: Retriever;
+
+  beforeEach(() => {
+    db = openDatabase({ dimensions: DIMS });
+    chunkStore = new ChunkStore(db);
+    embeddingStore = new EmbeddingStore(db);
+    dsStore = new DataSourceStore(db);
+    retriever = new Retriever(chunkStore, embeddingStore);
+
+    // Seed data
+    dsStore.insert('ds-1', 'owner', 'repo', 'main');
+    dsStore.insert('ds-2', 'owner', 'repo2', 'main');
+
+    const chunks: ChunkRecord[] = [
+      { id: 'c1', dataSourceId: 'ds-1', filePath: 'a.ts', startLine: 1, endLine: 5, content: 'function add(a, b) { return a + b; }', tokenCount: 10 },
+      { id: 'c2', dataSourceId: 'ds-1', filePath: 'b.ts', startLine: 1, endLine: 3, content: 'const x = 42;', tokenCount: 5 },
+      { id: 'c3', dataSourceId: 'ds-2', filePath: 'c.ts', startLine: 1, endLine: 10, content: 'class Foo {}', tokenCount: 4 },
+    ];
+
+    chunkStore.insertMany(chunks);
+
+    // Insert embeddings — make c1 closest to query [1,0,0,0]
+    embeddingStore.insert('c1', [0.9, 0.1, 0.0, 0.0]);
+    embeddingStore.insert('c2', [0.1, 0.9, 0.0, 0.0]);
+    embeddingStore.insert('c3', [0.0, 0.0, 0.9, 0.1]);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('returns ranked results for a query', async () => {
+    const provider = makeProvider([[1, 0, 0, 0]]);
+    const results = await retriever.search('add function', ['ds-1', 'ds-2'], provider, 10);
+
+    expect(results.length).toBe(3);
+    // c1 should be closest to [1,0,0,0]
+    expect(results[0].chunk.id).toBe('c1');
+  });
+
+  it('scopes results to specified data source IDs', async () => {
+    const provider = makeProvider([[0, 0, 0.9, 0.1]]);
+    const results = await retriever.search('class', ['ds-2'], provider, 10);
+
+    expect(results.length).toBe(1);
+    expect(results[0].chunk.id).toBe('c3');
+  });
+
+  it('searches all data sources when dataSourceIds is empty', async () => {
+    const provider = makeProvider([[1, 0, 0, 0]]);
+    const results = await retriever.search('query', [], provider, 10);
+
+    expect(results.length).toBe(3);
+  });
+
+  it('respects topK limit', async () => {
+    const provider = makeProvider([[1, 0, 0, 0]]);
+    const results = await retriever.search('query', [], provider, 1);
+
+    expect(results.length).toBe(1);
+  });
+
+  it('returns empty array when no embeddings exist', async () => {
+    // New empty DB
+    const emptyDb = openDatabase({ dimensions: DIMS });
+    const emptyChunkStore = new ChunkStore(emptyDb);
+    const emptyEmbeddingStore = new EmbeddingStore(emptyDb);
+    const emptyRetriever = new Retriever(emptyChunkStore, emptyEmbeddingStore);
+
+    const provider = makeProvider([[1, 0, 0, 0]]);
+    const results = await emptyRetriever.search('query', [], provider, 10);
+
+    expect(results).toEqual([]);
+    emptyDb.close();
+  });
+
+  it('hydrates chunk data in results', async () => {
+    const provider = makeProvider([[0.9, 0.1, 0, 0]]);
+    const results = await retriever.search('query', ['ds-1'], provider, 1);
+
+    expect(results[0].chunk.filePath).toBe('a.ts');
+    expect(results[0].chunk.content).toContain('function add');
+    expect(results[0].chunk.startLine).toBe(1);
+    expect(results[0].chunk.endLine).toBe(5);
+    expect(typeof results[0].distance).toBe('number');
+  });
+});

--- a/test/unit/tools/toolHandler.test.ts
+++ b/test/unit/tools/toolHandler.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock vscode before any imports that use it
+vi.mock('vscode', () => ({
+  workspace: {
+    getConfiguration: () => ({
+      get: (_key: string, defaultVal: any) => defaultVal,
+    }),
+  },
+  LanguageModelToolResult: class {
+    constructor(public parts: any[]) {}
+  },
+  LanguageModelTextPart: class {
+    constructor(public value: string) {}
+  },
+}));
+
+import { ToolHandler } from '../../../src/tools/toolHandler';
+import { EmbeddingProvider } from '../../../src/embedding/embeddingProvider';
+import { DataSourceConfig, ToolConfig } from '../../../src/config/configSchema';
+
+// --- Helpers ---
+
+function makeProvider(): EmbeddingProvider {
+  return {
+    id: 'test',
+    maxBatchSize: 100,
+    dimensions: 4,
+    embed: vi.fn().mockResolvedValue([[0.1, 0.2, 0.3, 0.4]]),
+    countTokens: (t: string) => Math.ceil(t.length / 4),
+  };
+}
+
+function makeDs(id: string, status: string = 'ready'): DataSourceConfig {
+  return {
+    id,
+    repoUrl: `https://github.com/test/${id}`,
+    owner: 'test',
+    repo: id,
+    branch: 'main',
+    includePatterns: [],
+    excludePatterns: [],
+    syncSchedule: 'manual',
+    lastSyncedAt: null,
+    lastSyncCommitSha: null,
+    status: status as any,
+  };
+}
+
+function makeTool(id: string, dsIds: string[]): ToolConfig {
+  return { id, name: `tool-${id}`, description: 'A test tool', dataSourceIds: dsIds };
+}
+
+function makeHandler(
+  dataSources: DataSourceConfig[],
+  tools: ToolConfig[],
+  searchResults: any[] = [],
+) {
+  const dsMap = new Map(dataSources.map((ds) => [ds.id, ds]));
+  const toolMap = new Map(tools.map((t) => [t.id, t]));
+
+  const configManager = {
+    getTool: (id: string) => toolMap.get(id),
+    getDataSources: () => dataSources,
+  } as any;
+
+  const provider = makeProvider();
+  const providerRegistry = {
+    getProvider: vi.fn().mockResolvedValue(provider),
+  } as any;
+
+  const retriever = {
+    search: vi.fn().mockResolvedValue(searchResults),
+  } as any;
+
+  const contextBuilder = {
+    format: vi.fn().mockReturnValue('formatted results'),
+  } as any;
+
+  const handler = new ToolHandler(configManager, providerRegistry, retriever, contextBuilder);
+  return { handler, retriever, contextBuilder, providerRegistry };
+}
+
+const dummyToken = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
+
+describe('ToolHandler', () => {
+  it('handleGlobalSearch searches all ready data sources', async () => {
+    const ds1 = makeDs('ds-1', 'ready');
+    const ds2 = makeDs('ds-2', 'indexing');
+    const { handler, retriever } = makeHandler([ds1, ds2], []);
+
+    const result = await handler.handleGlobalSearch(
+      { input: { query: 'test query' } } as any,
+      dummyToken as any,
+    );
+
+    // Should only pass ready data sources
+    expect(retriever.search).toHaveBeenCalledWith(
+      'test query',
+      ['ds-1'],
+      expect.anything(),
+      10, // default topK
+    );
+    expect(result.parts).toHaveLength(1);
+  });
+
+  it('handle searches scoped to tool data sources', async () => {
+    const ds1 = makeDs('ds-1');
+    const tool = makeTool('t-1', ['ds-1']);
+    const { handler, retriever } = makeHandler([ds1], [tool]);
+
+    await handler.handle(
+      't-1',
+      { input: { query: 'find me' } } as any,
+      dummyToken as any,
+    );
+
+    expect(retriever.search).toHaveBeenCalledWith(
+      'find me',
+      ['ds-1'],
+      expect.anything(),
+      10,
+    );
+  });
+
+  it('returns error for unknown tool ID', async () => {
+    const { handler } = makeHandler([], []);
+
+    const result = await handler.handle(
+      'nonexistent',
+      { input: { query: 'test' } } as any,
+      dummyToken as any,
+    );
+
+    expect(result.parts[0].value).toContain('not found');
+  });
+
+  it('returns error message when search fails', async () => {
+    const ds1 = makeDs('ds-1');
+    const { handler, retriever } = makeHandler([ds1], []);
+    retriever.search.mockRejectedValue(new Error('embedding failed'));
+
+    const result = await handler.handleGlobalSearch(
+      { input: { query: 'test' } } as any,
+      dummyToken as any,
+    );
+
+    expect(result.parts[0].value).toContain('Search failed');
+    expect(result.parts[0].value).toContain('embedding failed');
+  });
+
+  it('formats retrieval results via contextBuilder', async () => {
+    const ds1 = makeDs('ds-1');
+    const mockResults = [{ chunk: { id: 'c1' }, distance: 0.1 }];
+    const { handler, contextBuilder } = makeHandler([ds1], [], mockResults);
+    contextBuilder.format.mockReturnValue('**formatted**');
+
+    const result = await handler.handleGlobalSearch(
+      { input: { query: 'test' } } as any,
+      dummyToken as any,
+    );
+
+    expect(contextBuilder.format).toHaveBeenCalledWith(mockResults);
+    expect(result.parts[0].value).toBe('**formatted**');
+  });
+});

--- a/test/unit/tools/toolManager.test.ts
+++ b/test/unit/tools/toolManager.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Track registrations
+const registeredTools = new Map<string, any>();
+const disposedTools: string[] = [];
+
+vi.mock('vscode', () => ({
+  lm: {
+    registerTool: vi.fn().mockImplementation((name: string, handler: any) => {
+      registeredTools.set(name, handler);
+      return {
+        dispose: () => {
+          disposedTools.push(name);
+          registeredTools.delete(name);
+        },
+      };
+    }),
+  },
+}));
+
+import { ToolManager } from '../../../src/tools/toolManager';
+import { ToolConfig } from '../../../src/config/configSchema';
+
+function makeTool(id: string, name: string): ToolConfig {
+  return { id, name, description: 'Test tool', dataSourceIds: ['ds-1'] };
+}
+
+describe('ToolManager', () => {
+  let changeListeners: Array<() => void>;
+  let configTools: ToolConfig[];
+  let configManager: any;
+  let toolHandler: any;
+  let logger: any;
+
+  beforeEach(() => {
+    registeredTools.clear();
+    disposedTools.length = 0;
+    changeListeners = [];
+    configTools = [];
+
+    configManager = {
+      getTools: () => configTools,
+      onDidChange: (cb: () => void) => {
+        changeListeners.push(cb);
+        return { dispose: vi.fn() };
+      },
+    };
+
+    toolHandler = {
+      handle: vi.fn(),
+      handleGlobalSearch: vi.fn(),
+    };
+
+    logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+  });
+
+  it('registerAll registers the global search tool', () => {
+    const manager = new ToolManager(configManager, toolHandler, logger);
+    manager.registerAll();
+
+    expect(registeredTools.has('repolens-search')).toBe(true);
+    manager.dispose();
+  });
+
+  it('registerAll registers user-configured tools', () => {
+    configTools = [makeTool('t-1', 'my-tool'), makeTool('t-2', 'other-tool')];
+    const manager = new ToolManager(configManager, toolHandler, logger);
+    manager.registerAll();
+
+    expect(registeredTools.has('repolens-my-tool')).toBe(true);
+    expect(registeredTools.has('repolens-other-tool')).toBe(true);
+    manager.dispose();
+  });
+
+  it('does not duplicate global tool on repeated registerAll calls', () => {
+    const manager = new ToolManager(configManager, toolHandler, logger);
+    manager.registerAll();
+    manager.registerAll();
+
+    // Only registered once — if it were duplicated, dispose would show 2 entries
+    manager.dispose();
+    const globalDisposals = disposedTools.filter((n) => n === 'repolens-search');
+    expect(globalDisposals.length).toBe(1);
+  });
+
+  it('syncRegistrations adds new tools from config', () => {
+    const manager = new ToolManager(configManager, toolHandler, logger);
+    manager.registerAll();
+
+    expect(registeredTools.has('repolens-new-tool')).toBe(false);
+
+    // Simulate config change — add a new tool
+    configTools = [makeTool('t-new', 'new-tool')];
+    changeListeners.forEach((cb) => cb());
+
+    expect(registeredTools.has('repolens-new-tool')).toBe(true);
+    manager.dispose();
+  });
+
+  it('syncRegistrations removes tools no longer in config', () => {
+    configTools = [makeTool('t-1', 'old-tool')];
+    const manager = new ToolManager(configManager, toolHandler, logger);
+    manager.registerAll();
+
+    expect(registeredTools.has('repolens-old-tool')).toBe(true);
+
+    // Remove the tool from config and trigger sync
+    configTools = [];
+    changeListeners.forEach((cb) => cb());
+
+    expect(disposedTools).toContain('repolens-old-tool');
+    manager.dispose();
+  });
+
+  it('dispose cleans up all registered tools', () => {
+    configTools = [makeTool('t-1', 'tool-a')];
+    const manager = new ToolManager(configManager, toolHandler, logger);
+    manager.registerAll();
+
+    manager.dispose();
+
+    expect(disposedTools).toContain('repolens-search');
+    expect(disposedTools).toContain('repolens-tool-a');
+  });
+
+  it('keeps global tool during syncRegistrations', () => {
+    const manager = new ToolManager(configManager, toolHandler, logger);
+    manager.registerAll();
+
+    // Trigger sync with empty config
+    configTools = [];
+    changeListeners.forEach((cb) => cb());
+
+    // Global tool should still be registered
+    expect(registeredTools.has('repolens-search')).toBe(true);
+    expect(disposedTools).not.toContain('repolens-search');
+    manager.dispose();
+  });
+});


### PR DESCRIPTION
Slice 5 — Retrieval & Tool Registration:
- Tests for Retriever: ranked search, scoping by data source, topK limit
- Tests for ContextBuilder: formatting with repo labels, line ranges, code blocks
- Tests for ToolHandler: global search, scoped tool search, error handling
- Tests for ToolManager: registration, config-driven sync, disposal

Slice 6 — Config & Extension Wiring:
- Harden ConfigManager with corrupt JSON recovery (backup + reset to defaults)
- Add debounced writes (300ms) to coalesce rapid config updates
- Add file watcher for external config edits with automatic reload
- Add flush() method for immediate write when needed
- Tests for ConfigManager: CRUD round-trips, corrupt recovery, debounce, persistence, external file change reload

159 tests passing, clean type-check.

https://claude.ai/code/session_01SivoQnekKoktVbgMjSnAd7