### PR TITLE
Implement Slices 9 & 10: Delta Sync, Progress, Polish

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import { ToolManager } from './tools/toolManager';
 import { DataSourceTreeProvider, ToolTreeProvider } from './ui/sidebar/sidebarProvider';
 import { AddRepoWizard } from './ui/wizard/addRepoWizard';
 import { registerCommands } from './ui/commands';
+import { DeltaSync } from './sources/sync/deltaSync';
 import { Logger } from './util/logger';
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -46,6 +47,9 @@ export function activate(context: vscode.ExtensionContext): void {
   const embeddingStore = new EmbeddingStore(db);
   const syncStore = new SyncStore(db);
 
+  // Delta sync
+  const deltaSync = new DeltaSync(getToken);
+
   // Ingestion
   const pipeline = new IngestionPipeline(
     configManager,
@@ -55,6 +59,7 @@ export function activate(context: vscode.ExtensionContext): void {
     embeddingStore,
     syncStore,
     logger,
+    deltaSync,
   );
 
   // Data source management

--- a/src/ingestion/pipeline.ts
+++ b/src/ingestion/pipeline.ts
@@ -2,6 +2,7 @@ import * as crypto from 'crypto';
 import { DataSourceConfig } from '../config/configSchema';
 import { EmbeddingProvider } from '../embedding/embeddingProvider';
 import { GitHubFetcher } from '../sources/github/githubFetcher';
+import { DeltaSync } from '../sources/sync/deltaSync';
 import { FileFilter } from './fileFilter';
 import { Chunker } from './chunker';
 import { ChunkStore, ChunkRecord } from '../storage/chunkStore';
@@ -9,35 +10,32 @@ import { EmbeddingStore } from '../storage/embeddingStore';
 import { SyncStore } from '../storage/syncStore';
 
 const MAX_CONCURRENCY = 3;
+const LARGE_REPO_THRESHOLD = 10_000;
 
-/**
- * Minimal interface for config access — decoupled from VS Code.
- */
 export interface PipelineConfigSource {
   getDataSource(id: string): DataSourceConfig | undefined;
   getDefaultExcludePatterns(): string[];
   updateDataSource(id: string, updates: Partial<DataSourceConfig>): void;
 }
 
-/**
- * Minimal interface for embedding provider resolution.
- */
 export interface PipelineEmbeddingSource {
   getProvider(): Promise<EmbeddingProvider>;
 }
 
-/**
- * Minimal logger interface — decoupled from VS Code OutputChannel.
- */
 export interface PipelineLogger {
   info(message: string): void;
   warn(message: string): void;
   error(message: string): void;
 }
 
+export interface PipelineProgress {
+  report(message: string, increment?: number): void;
+}
+
 export class IngestionPipeline {
   private readonly queue: string[] = [];
   private readonly running = new Set<string>();
+  private disposed = false;
 
   constructor(
     private readonly config: PipelineConfigSource,
@@ -47,6 +45,7 @@ export class IngestionPipeline {
     private readonly embeddingStore: EmbeddingStore,
     private readonly syncStore: SyncStore,
     private readonly logger: PipelineLogger,
+    private readonly deltaSync?: DeltaSync,
   ) {}
 
   get queueSize(): number {
@@ -58,6 +57,7 @@ export class IngestionPipeline {
   }
 
   enqueue(dataSourceId: string): void {
+    if (this.disposed) return;
     if (this.queue.includes(dataSourceId) || this.running.has(dataSourceId)) {
       return;
     }
@@ -72,12 +72,14 @@ export class IngestionPipeline {
       this.running.add(id);
       this.ingestDataSource(id).finally(() => {
         this.running.delete(id);
-        this.processQueue();
+        if (!this.disposed) {
+          this.processQueue();
+        }
       });
     }
   }
 
-  async ingestDataSource(dataSourceId: string): Promise<void> {
+  async ingestDataSource(dataSourceId: string, progress?: PipelineProgress): Promise<void> {
     const ds = this.config.getDataSource(dataSourceId);
     if (!ds) return;
 
@@ -87,73 +89,23 @@ export class IngestionPipeline {
     try {
       this.config.updateDataSource(dataSourceId, { status: 'indexing' });
       this.logger.info(`Indexing ${ds.owner}/${ds.repo}@${ds.branch}`);
+      progress?.report(`Fetching ${ds.owner}/${ds.repo}...`);
 
       // Get current HEAD
       commitSha = await this.fetcher.getBranchSha(ds.owner, ds.repo, ds.branch);
       this.syncStore.startSync(syncId, dataSourceId, commitSha);
 
-      // Fetch file tree
-      const { entries: tree, truncated } = await this.fetcher.getTree(ds.owner, ds.repo, commitSha);
-      if (truncated) {
-        this.logger.warn(`File tree for ${ds.owner}/${ds.repo} was truncated by GitHub API`);
+      // Try delta sync if we have a previous commit
+      if (ds.lastSyncCommitSha && this.deltaSync && commitSha !== ds.lastSyncCommitSha) {
+        const didDelta = await this.tryDeltaSync(
+          ds, dataSourceId, syncId, commitSha, progress,
+        );
+        if (didDelta) return;
+        // Delta failed — fall through to full re-index
+        this.logger.warn(`Delta sync failed for ${ds.owner}/${ds.repo}, falling back to full re-index`);
       }
 
-      // Filter files
-      const filter = new FileFilter(
-        ds.includePatterns,
-        [...ds.excludePatterns, ...this.config.getDefaultExcludePatterns()],
-      );
-      const filteredEntries = tree.filter((entry) => filter.matches(entry.path));
-
-      this.logger.info(`Fetching ${filteredEntries.length} files`);
-
-      // Clear existing data for this source (full re-index)
-      const oldChunkIds = this.chunkStore.getChunkIdsByDataSource(dataSourceId);
-      this.embeddingStore.deleteByChunkIds(oldChunkIds);
-      this.chunkStore.deleteByDataSource(dataSourceId);
-
-      // Fetch file contents
-      const files = await this.fetcher.fetchFiles(ds.owner, ds.repo, filteredEntries);
-
-      // Get embedding provider and build chunker with its tokenizer
-      const provider = await this.embeddingSource.getProvider();
-      const chunker = new Chunker({
-        countTokens: provider.countTokens
-          ? (text: string) => provider.countTokens!(text)
-          : undefined,
-      });
-
-      // Chunk all files
-      const allChunks: ChunkRecord[] = [];
-      for (const file of files) {
-        const chunks = chunker.chunkFile(file.content, file.path);
-        for (const chunk of chunks) {
-          allChunks.push({
-            id: crypto.randomUUID(),
-            dataSourceId,
-            filePath: file.path,
-            startLine: chunk.startLine,
-            endLine: chunk.endLine,
-            content: chunk.content,
-            tokenCount: chunk.tokenCount,
-          });
-        }
-      }
-
-      // Store chunks
-      this.chunkStore.insertMany(allChunks);
-
-      // Embed in batches
-      await this.embedChunks(allChunks, provider);
-
-      // Update state
-      this.config.updateDataSource(dataSourceId, {
-        status: 'ready',
-        lastSyncedAt: new Date().toISOString(),
-        lastSyncCommitSha: commitSha,
-      });
-      this.syncStore.completeSync(syncId, files.length, allChunks.length);
-      this.logger.info(`Indexed ${allChunks.length} chunks from ${files.length} files`);
+      await this.fullReindex(ds, dataSourceId, syncId, commitSha, progress);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.config.updateDataSource(dataSourceId, {
@@ -165,9 +117,171 @@ export class IngestionPipeline {
     }
   }
 
+  private async tryDeltaSync(
+    ds: DataSourceConfig,
+    dataSourceId: string,
+    syncId: string,
+    commitSha: string,
+    progress?: PipelineProgress,
+  ): Promise<boolean> {
+    try {
+      const delta = await this.deltaSync!.computeDelta(
+        ds.owner, ds.repo, ds.lastSyncCommitSha!, commitSha,
+      );
+
+      const filter = this.buildFilter(ds);
+      const addedFiltered = delta.added.filter((e) => filter.matches(e.path));
+      const modifiedFiltered = delta.modified.filter((e) => filter.matches(e.path));
+      const deletedFiltered = delta.deleted.filter((p) => filter.matches(p));
+
+      const totalChanges = addedFiltered.length + modifiedFiltered.length + deletedFiltered.length;
+      this.logger.info(
+        `Delta: ${addedFiltered.length} added, ${modifiedFiltered.length} modified, ${deletedFiltered.length} deleted`,
+      );
+      progress?.report(`Processing ${totalChanges} changed files...`);
+
+      // Delete chunks for removed and modified files
+      for (const filePath of deletedFiltered) {
+        const chunkIds = this.chunkStore.getChunkIdsByFile(dataSourceId, filePath);
+        this.embeddingStore.deleteByChunkIds(chunkIds);
+        this.chunkStore.deleteByFile(dataSourceId, filePath);
+      }
+      for (const entry of modifiedFiltered) {
+        const chunkIds = this.chunkStore.getChunkIdsByFile(dataSourceId, entry.path);
+        this.embeddingStore.deleteByChunkIds(chunkIds);
+        this.chunkStore.deleteByFile(dataSourceId, entry.path);
+      }
+
+      // Fetch and chunk added + modified files
+      const toFetch = [...addedFiltered, ...modifiedFiltered];
+      if (toFetch.length > 0) {
+        const files = await this.fetcher.fetchFiles(ds.owner, ds.repo, toFetch);
+        const provider = await this.embeddingSource.getProvider();
+        const chunker = new Chunker({
+          countTokens: provider.countTokens
+            ? (text: string) => provider.countTokens!(text)
+            : undefined,
+        });
+
+        const allChunks: ChunkRecord[] = [];
+        for (const file of files) {
+          const chunks = chunker.chunkFile(file.content, file.path);
+          for (const chunk of chunks) {
+            allChunks.push({
+              id: crypto.randomUUID(),
+              dataSourceId,
+              filePath: file.path,
+              startLine: chunk.startLine,
+              endLine: chunk.endLine,
+              content: chunk.content,
+              tokenCount: chunk.tokenCount,
+            });
+          }
+        }
+
+        this.chunkStore.insertMany(allChunks);
+        await this.embedChunks(allChunks, provider, progress);
+      }
+
+      this.config.updateDataSource(dataSourceId, {
+        status: 'ready',
+        lastSyncedAt: new Date().toISOString(),
+        lastSyncCommitSha: commitSha,
+      });
+      this.syncStore.completeSync(syncId, toFetch.length, this.chunkStore.countByDataSource(dataSourceId));
+      this.logger.info(`Delta sync complete for ${ds.owner}/${ds.repo}`);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async fullReindex(
+    ds: DataSourceConfig,
+    dataSourceId: string,
+    syncId: string,
+    commitSha: string,
+    progress?: PipelineProgress,
+  ): Promise<void> {
+    // Fetch file tree
+    const { entries: tree, truncated } = await this.fetcher.getTree(ds.owner, ds.repo, commitSha);
+    if (truncated) {
+      this.logger.warn(`File tree for ${ds.owner}/${ds.repo} was truncated by GitHub API`);
+    }
+
+    const filter = this.buildFilter(ds);
+    const filteredEntries = tree.filter((entry) => filter.matches(entry.path));
+
+    if (filteredEntries.length > LARGE_REPO_THRESHOLD) {
+      this.logger.warn(
+        `Large repository: ${filteredEntries.length} files after filtering for ${ds.owner}/${ds.repo}`,
+      );
+    }
+
+    this.logger.info(`Fetching ${filteredEntries.length} files`);
+    progress?.report(`Fetching ${filteredEntries.length} files...`);
+
+    // Clear existing data for this source (full re-index)
+    const oldChunkIds = this.chunkStore.getChunkIdsByDataSource(dataSourceId);
+    this.embeddingStore.deleteByChunkIds(oldChunkIds);
+    this.chunkStore.deleteByDataSource(dataSourceId);
+
+    // Fetch file contents
+    const files = await this.fetcher.fetchFiles(ds.owner, ds.repo, filteredEntries);
+
+    // Get embedding provider and build chunker
+    const provider = await this.embeddingSource.getProvider();
+    const chunker = new Chunker({
+      countTokens: provider.countTokens
+        ? (text: string) => provider.countTokens!(text)
+        : undefined,
+    });
+
+    // Chunk all files
+    const allChunks: ChunkRecord[] = [];
+    for (const file of files) {
+      const chunks = chunker.chunkFile(file.content, file.path);
+      for (const chunk of chunks) {
+        allChunks.push({
+          id: crypto.randomUUID(),
+          dataSourceId,
+          filePath: file.path,
+          startLine: chunk.startLine,
+          endLine: chunk.endLine,
+          content: chunk.content,
+          tokenCount: chunk.tokenCount,
+        });
+      }
+    }
+
+    // Store chunks
+    this.chunkStore.insertMany(allChunks);
+    progress?.report(`Embedding ${allChunks.length} chunks...`);
+
+    // Embed in batches
+    await this.embedChunks(allChunks, provider, progress);
+
+    // Update state
+    this.config.updateDataSource(dataSourceId, {
+      status: 'ready',
+      lastSyncedAt: new Date().toISOString(),
+      lastSyncCommitSha: commitSha,
+    });
+    this.syncStore.completeSync(syncId, files.length, allChunks.length);
+    this.logger.info(`Indexed ${allChunks.length} chunks from ${files.length} files`);
+  }
+
+  private buildFilter(ds: DataSourceConfig): FileFilter {
+    return new FileFilter(
+      ds.includePatterns,
+      [...ds.excludePatterns, ...this.config.getDefaultExcludePatterns()],
+    );
+  }
+
   private async embedChunks(
     chunks: ChunkRecord[],
     provider: EmbeddingProvider,
+    progress?: PipelineProgress,
   ): Promise<void> {
     const batchSize = provider.maxBatchSize;
 
@@ -181,6 +295,7 @@ export class IngestionPipeline {
         embedding: embeddings[idx],
       }));
       this.embeddingStore.insertMany(items);
+      progress?.report(`Embedded ${Math.min(i + batchSize, chunks.length)}/${chunks.length} chunks`);
     }
   }
 
@@ -191,6 +306,7 @@ export class IngestionPipeline {
   }
 
   dispose(): void {
+    this.disposed = true;
     this.queue.length = 0;
   }
 }

--- a/test/unit/ingestion/pipeline.test.ts
+++ b/test/unit/ingestion/pipeline.test.ts
@@ -87,6 +87,7 @@ describe('IngestionPipeline', () => {
   function makePipeline(
     dataSources: DataSourceConfig[],
     provider?: EmbeddingProvider,
+    deltaSync?: any,
   ) {
     const dsMap = new Map(dataSources.map((ds) => [ds.id, { ...ds }]));
 
@@ -120,6 +121,7 @@ describe('IngestionPipeline', () => {
         embeddingStore,
         syncStore,
         logger,
+        deltaSync,
       ),
       config,
       logger,
@@ -374,5 +376,109 @@ describe('IngestionPipeline', () => {
     pipeline.dispose();
     // Don't close testDb — the hanging promises may reference it.
     // In-memory DBs are cleaned up on GC.
+  });
+
+  it('uses delta sync when lastSyncCommitSha is set', async () => {
+    const ds = makeDataSource({ lastSyncCommitSha: 'old-sha' });
+    const files = [{ path: 'a.ts', content: 'original content' }];
+    mockGitHubApi(files);
+
+    const mockDeltaSync = {
+      computeDelta: vi.fn().mockResolvedValue({
+        added: [{ path: 'new.ts', sha: 'blob-sha-0', size: 10, type: 'blob' }],
+        modified: [],
+        deleted: [],
+        unchanged: ['a.ts'],
+        newCommitSha: 'abc123',
+      }),
+    };
+
+    const { pipeline, dsMap } = makePipeline([ds], undefined, mockDeltaSync);
+
+    // First do a full index so there's existing data
+    await pipeline.ingestDataSource('ds-1');
+    const countAfterFull = chunkStore.countByDataSource('ds-1');
+    expect(countAfterFull).toBeGreaterThan(0);
+
+    // Now set lastSyncCommitSha and re-ingest — should use delta
+    dsMap.get('ds-1')!.lastSyncCommitSha = 'old-sha';
+    await pipeline.ingestDataSource('ds-1');
+
+    expect(mockDeltaSync.computeDelta).toHaveBeenCalledWith(
+      'test', 'repo', 'old-sha', 'abc123',
+    );
+    expect(dsMap.get('ds-1')!.status).toBe('ready');
+  });
+
+  it('falls back to full reindex when delta sync fails', async () => {
+    const ds = makeDataSource({ lastSyncCommitSha: 'old-sha' });
+    const files = [{ path: 'a.ts', content: 'content' }];
+    mockGitHubApi(files);
+
+    const mockDeltaSync = {
+      computeDelta: vi.fn().mockRejectedValue(new Error('compare failed')),
+    };
+
+    const { pipeline, dsMap, logger } = makePipeline([ds], undefined, mockDeltaSync);
+    await pipeline.ingestDataSource('ds-1');
+
+    // Should still succeed via full reindex
+    expect(dsMap.get('ds-1')!.status).toBe('ready');
+    expect((logger.warn as ReturnType<typeof vi.fn>).mock.calls.some(
+      (c: string[]) => c[0].includes('falling back'),
+    )).toBe(true);
+  });
+
+  it('delta sync removes chunks for deleted files', async () => {
+    const ds = makeDataSource();
+    const files = [
+      { path: 'a.ts', content: 'file a content' },
+      { path: 'b.ts', content: 'file b content' },
+    ];
+    mockGitHubApi(files);
+
+    const mockDeltaSync = {
+      computeDelta: vi.fn().mockResolvedValue({
+        added: [],
+        modified: [],
+        deleted: ['a.ts'],
+        unchanged: ['b.ts'],
+        newCommitSha: 'abc123',
+      }),
+    };
+
+    const { pipeline, dsMap } = makePipeline([ds], undefined, mockDeltaSync);
+
+    // Full index first
+    await pipeline.ingestDataSource('ds-1');
+    const chunksBeforeDelta = chunkStore.getByDataSource('ds-1');
+    const aChunks = chunksBeforeDelta.filter((c) => c.filePath === 'a.ts');
+    expect(aChunks.length).toBeGreaterThan(0);
+
+    // Delta sync — delete a.ts
+    dsMap.get('ds-1')!.lastSyncCommitSha = 'prev-sha';
+    await pipeline.ingestDataSource('ds-1');
+
+    const chunksAfterDelta = chunkStore.getByDataSource('ds-1');
+    const aChunksAfter = chunksAfterDelta.filter((c) => c.filePath === 'a.ts');
+    expect(aChunksAfter).toHaveLength(0);
+    // b.ts should still exist
+    const bChunksAfter = chunksAfterDelta.filter((c) => c.filePath === 'b.ts');
+    expect(bChunksAfter.length).toBeGreaterThan(0);
+  });
+
+  it('reports progress during ingestion', async () => {
+    const ds = makeDataSource();
+    const files = [{ path: 'a.ts', content: 'hello world' }];
+    mockGitHubApi(files);
+
+    const { pipeline } = makePipeline([ds]);
+    const progress = { report: vi.fn() };
+
+    await pipeline.ingestDataSource('ds-1', progress);
+
+    expect(progress.report).toHaveBeenCalled();
+    const messages = progress.report.mock.calls.map((c: any) => c[0]);
+    expect(messages.some((m: string) => m.includes('Fetching'))).toBe(true);
   });
 });

--- a/test/unit/sources/deltaSync.test.ts
+++ b/test/unit/sources/deltaSync.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DeltaSync } from '../../../src/sources/sync/deltaSync';
+
+describe('DeltaSync', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function makeDeltaSync() {
+    return new DeltaSync(async () => 'test-token');
+  }
+
+  it('classifies added, modified, and removed files', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        files: [
+          { filename: 'new.ts', status: 'added', sha: 'sha-1' },
+          { filename: 'changed.ts', status: 'modified', sha: 'sha-2' },
+          { filename: 'old.ts', status: 'removed', sha: 'sha-3' },
+        ],
+      }),
+    });
+
+    const ds = makeDeltaSync();
+    const result = await ds.computeDelta('owner', 'repo', 'base-sha', 'head-sha');
+
+    expect(result.added).toHaveLength(1);
+    expect(result.added[0].path).toBe('new.ts');
+    expect(result.modified).toHaveLength(1);
+    expect(result.modified[0].path).toBe('changed.ts');
+    expect(result.deleted).toEqual(['old.ts']);
+    expect(result.newCommitSha).toBe('head-sha');
+  });
+
+  it('treats renamed files as modified', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        files: [
+          { filename: 'renamed.ts', status: 'renamed', sha: 'sha-1' },
+        ],
+      }),
+    });
+
+    const ds = makeDeltaSync();
+    const result = await ds.computeDelta('o', 'r', 'a', 'b');
+
+    expect(result.modified).toHaveLength(1);
+    expect(result.modified[0].path).toBe('renamed.ts');
+    expect(result.deleted).toHaveLength(0);
+  });
+
+  it('throws on API error', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+
+    const ds = makeDeltaSync();
+    await expect(ds.computeDelta('o', 'r', 'a', 'b')).rejects.toThrow('404');
+  });
+
+  it('calls correct compare endpoint', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ files: [] }),
+    });
+
+    const ds = makeDeltaSync();
+    await ds.computeDelta('owner', 'repo', 'base123', 'head456');
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/repos/owner/repo/compare/base123...head456'),
+      expect.anything(),
+    );
+  });
+});

--- a/test/unit/sources/syncScheduler.test.ts
+++ b/test/unit/sources/syncScheduler.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('vscode', () => ({
+  workspace: {
+    getConfiguration: () => ({
+      get: (_key: string, defaultVal: any) => defaultVal,
+    }),
+  },
+}));
+
+import { SyncScheduler } from '../../../src/sources/sync/syncScheduler';
+
+function makeDs(id: string, schedule: string, lastSyncedAt: string | null = null) {
+  return {
+    id,
+    syncSchedule: schedule,
+    lastSyncedAt,
+    owner: 'o',
+    repo: 'r',
+    branch: 'main',
+  };
+}
+
+describe('SyncScheduler', () => {
+  let onSync: ReturnType<typeof vi.fn>;
+  let configManager: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onSync = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('triggers onStartup data sources on start', () => {
+    configManager = {
+      getDataSources: () => [
+        makeDs('ds-1', 'onStartup'),
+        makeDs('ds-2', 'manual'),
+        makeDs('ds-3', 'onStartup'),
+      ],
+    };
+
+    const scheduler = new SyncScheduler(configManager, onSync);
+    scheduler.start();
+
+    expect(onSync).toHaveBeenCalledWith('ds-1');
+    expect(onSync).toHaveBeenCalledWith('ds-3');
+    expect(onSync).not.toHaveBeenCalledWith('ds-2');
+
+    scheduler.dispose();
+  });
+
+  it('does not trigger manual sources on startup', () => {
+    configManager = {
+      getDataSources: () => [makeDs('ds-1', 'manual')],
+    };
+
+    const scheduler = new SyncScheduler(configManager, onSync);
+    scheduler.start();
+
+    expect(onSync).not.toHaveBeenCalled();
+    scheduler.dispose();
+  });
+
+  it('triggers daily sources that have never synced', () => {
+    configManager = {
+      getDataSources: () => [makeDs('ds-1', 'daily', null)],
+    };
+
+    const scheduler = new SyncScheduler(configManager, onSync);
+    scheduler.start();
+    onSync.mockClear();
+
+    // Advance 1 hour to trigger the daily check
+    vi.advanceTimersByTime(60 * 60 * 1000);
+
+    expect(onSync).toHaveBeenCalledWith('ds-1');
+    scheduler.dispose();
+  });
+
+  it('triggers daily sources older than 24 hours', () => {
+    const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    configManager = {
+      getDataSources: () => [makeDs('ds-1', 'daily', oldDate)],
+    };
+
+    const scheduler = new SyncScheduler(configManager, onSync);
+    scheduler.start();
+    onSync.mockClear();
+
+    vi.advanceTimersByTime(60 * 60 * 1000);
+
+    expect(onSync).toHaveBeenCalledWith('ds-1');
+    scheduler.dispose();
+  });
+
+  it('skips daily sources synced less than 24 hours ago', () => {
+    const recentDate = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+    configManager = {
+      getDataSources: () => [makeDs('ds-1', 'daily', recentDate)],
+    };
+
+    const scheduler = new SyncScheduler(configManager, onSync);
+    scheduler.start();
+    onSync.mockClear();
+
+    vi.advanceTimersByTime(60 * 60 * 1000);
+
+    expect(onSync).not.toHaveBeenCalled();
+    scheduler.dispose();
+  });
+
+  it('cleans up interval on dispose', () => {
+    configManager = { getDataSources: () => [] };
+    const scheduler = new SyncScheduler(configManager, onSync);
+    scheduler.start();
+    scheduler.dispose();
+
+    // Advancing timers should not trigger anything
+    onSync.mockClear();
+    vi.advanceTimersByTime(2 * 60 * 60 * 1000);
+    expect(onSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Slice 9 — Sync & Delta Updates:
- Wire DeltaSync into IngestionPipeline with optional deltaSync param
- Delta-aware path: when lastSyncCommitSha exists, compute delta via GitHub Compare API, only process added/modified/deleted files
- Deleted files: remove their chunks and embeddings
- Modified files: delete old chunks, re-chunk, re-embed
- Falls back to full re-index if delta sync fails
- Wire DeltaSync into extension.ts activate()
- Tests: DeltaSync (4), SyncScheduler (6), pipeline delta tests (4)

Slice 10 — Error Handling & Polish:
- Add PipelineProgress interface for reporting status
- Large repo warning when >10K files after filtering
- Pipeline disposed flag prevents enqueue after dispose
- Progress reporting throughout: fetch, chunk, embed phases

212 tests passing, clean type-check.

https://claude.ai/code/session_01SivoQnekKoktVbgMjSnAd7