### PR TITLE
Fix native module arch mismatch on Apple Silicon

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -2,17 +2,20 @@ name: _build
 
 on:
   workflow_call:
-    outputs:
-      artifact-name:
-        description: Name of the uploaded VSIX artifact
-        value: ${{ jobs.build.outputs.artifact-name }}
 
 jobs:
   build:
-    name: Build and package
-    runs-on: ubuntu-latest
-    outputs:
-      artifact-name: ${{ steps.upload.outputs.artifact-name }}
+    name: Build (${{ matrix.target }})
+    strategy:
+      matrix:
+        include:
+          - target: linux-x64
+            os: ubuntu-latest
+          - target: darwin-arm64
+            os: macos-latest
+          - target: darwin-x64
+            os: macos-13
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -24,12 +27,11 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npx vsce package --no-dependencies
+      - run: npx vsce package --target ${{ matrix.target }}
 
       - name: Upload VSIX
-        id: upload
         uses: actions/upload-artifact@v4
         with:
-          name: vsix
+          name: vsix-${{ matrix.target }}
           path: '*.vsix'
           retention-days: 7

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,14 +20,11 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: vsix
-
-      - name: Get VSIX filename
-        id: vsix
-        run: echo "file=$(ls *.vsix)" >> "$GITHUB_OUTPUT"
+          pattern: vsix-*
+          merge-multiple: true
 
       - uses: softprops/action-gh-release@v2
         with:
           prerelease: true
-          files: ${{ steps.vsix.outputs.file }}
+          files: '*.vsix'
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,11 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: vsix
-
-      - name: Get VSIX filename
-        id: vsix
-        run: echo "file=$(ls *.vsix)" >> "$GITHUB_OUTPUT"
+          pattern: vsix-*
+          merge-multiple: true
 
       - uses: softprops/action-gh-release@v2
         with:
           prerelease: false
-          files: ${{ steps.vsix.outputs.file }}
+          files: '*.vsix'
           generate_release_notes: true

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,5 @@
 .github/**
 .vscode-test/**
-node_modules/**
 src/**
 test/**
 docs/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,18 @@ npx vitest run test/unit/storage/database.test.ts
 
 **Note:** Storage tests (`test/unit/storage/`) crash locally on Apple Silicon when Node runs as x64 under Rosetta 2 — `sqlite-vec`'s prebuilt binary uses AVX instructions Rosetta doesn't support. These tests pass on native x86_64 (GitHub CI). Embedding tests always pass.
 
+## Dev Workflow (build → install → run)
+
+```bash
+npm run dev:install    # build + vsce package + code --install-extension + open new window
+# or directly:
+bash scripts/dev-install.sh
+```
+
+This produces `repolens-dev.vsix`, installs it, and opens a new VS Code window. Use this whenever you want to manually test a change end-to-end.
+
+**Viewing logs:** View → Output → select **RepoLens**. Set `repoLens.log.level = "debug"` in settings for verbose output.
+
 ## Packaging and Local Install
 
 ```bash
@@ -30,18 +42,20 @@ To uninstall:
 code --uninstall-extension repolens.repolens
 ```
 
-The `--no-dependencies` flag is passed in CI (`npx vsce package --no-dependencies`) to skip bundling node_modules into the VSIX — the extension relies on VS Code's Node runtime, not a bundled tree.
+Dependencies (including native modules like `better-sqlite3` and `sqlite-vec`) are bundled into the VSIX. CI builds platform-specific VSIXs via `vsce package --target <platform>` on matching runners (linux-x64, darwin-arm64, darwin-x64).
+
+**Apple Silicon note:** `dev-install.sh` detects x64 Node running under Rosetta and automatically rebuilds native modules for arm64 before packaging.
 
 ## Releasing
 
-Push a version tag to trigger the release workflow, which builds the VSIX and publishes a GitHub prerelease:
+Push a version tag to trigger the release workflow, which builds platform-specific VSIXs and publishes a GitHub release:
 
 ```bash
 git tag v0.0.1
 git push origin v0.0.1
 ```
 
-The workflow (`.github/workflows/release.yml`) runs on any `v*` tag, packages the VSIX, and attaches it to the GitHub release.
+The workflow (`.github/workflows/release.yml`) runs on any `v*` tag, builds for each platform via `_build.yml`, and attaches all VSIXs to the release.
 
 ## Architecture Overview
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ RepoLens indexes GitHub repositories into a local SQLite vector database and exp
 
 ## Setup
 
-1. Install the extension (see [Installing Locally](#installing-locally) or grab a release VSIX from [Releases](../../releases))
+1. Install the extension (see [Installing Locally](#installing-locally) or grab a release VSIX from [Releases](https://github.com/colbymk97/repo-lens/releases))
 2. Run **RepoLens: Set OpenAI API Key** from the command palette
 3. Open the RepoLens sidebar and add a repository
 4. Wait for indexing to complete, then ask Copilot about it
@@ -29,7 +29,7 @@ RepoLens indexes GitHub repositories into a local SQLite vector database and exp
 
 ### From a release VSIX
 
-Download the `.vsix` file from the [Releases](../../releases) page, then:
+Download the `.vsix` file from the [Releases](https://github.com/colbymk97/repo-lens/releases) page, then:
 
 ```bash
 code --install-extension repolens-0.0.1.vsix
@@ -40,7 +40,7 @@ Or via the VS Code UI: Extensions panel → `...` menu → **Install from VSIX..
 ### Build and install from source
 
 ```bash
-git clone https://github.com/colbyking/Lens.git
+git clone https://github.com/colbymk97/repo-lens.git
 cd Lens
 npm install
 npm run build
@@ -73,9 +73,18 @@ npm run watch          # Incremental compile on save
 npm run lint           # ESLint
 npm test               # Vitest unit tests
 npm run package        # Build VSIX (runs vsce package)
+npm run dev:install    # Build, install, and open a new VS Code window
 ```
 
 > **Apple Silicon note:** Storage tests (`test/unit/storage/`) crash locally when Node runs as x64 under Rosetta 2 — `sqlite-vec` uses AVX instructions Rosetta doesn't support. These tests pass on native x86_64 / GitHub CI. Embedding tests always pass.
+
+### Viewing logs
+
+RepoLens writes to a VS Code Output Channel. To open it:
+
+**View → Output**, then select **RepoLens** from the dropdown in the top-right of the panel.
+
+To enable verbose logging, set `repoLens.log.level` to `"debug"` in your VS Code settings — this surfaces chunking, embedding, and sync details.
 
 ## CI and Releases
 
@@ -96,7 +105,7 @@ git tag v0.0.1-alpha.1
 git push origin v0.0.1-alpha.1
 ```
 
-The VSIX will be attached to the GitHub release automatically. Download it from the [Releases](../../releases) page to test.
+The VSIX will be attached to the GitHub release automatically. Download it from the [Releases](https://github.com/colbymk97/repo-lens/releases) page to test.
 
 ### Publishing a stable release
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Use any GitHub repository as RAG context for Copilot — query codebases, docs, and institutional knowledge without leaving VS Code.",
   "version": "0.0.1",
   "publisher": "repolens",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/colbymk97/repo-lens.git"
+  },
   "license": "MIT",
   "engines": {
     "vscode": "^1.99.0"
@@ -158,7 +162,8 @@
     "lint": "eslint src/",
     "test": "vitest run",
     "test:watch": "vitest",
-    "package": "vsce package"
+    "package": "vsce package",
+    "dev:install": "bash scripts/dev-install.sh"
   },
   "dependencies": {
     "better-sqlite3": "^11.7.0",

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# dev-install.sh — build, install, and launch a fresh VS Code window with RepoLens active
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Find the 'code' binary — prefer PATH, fall back to known macOS app locations
+if command -v code &>/dev/null; then
+  CODE=code
+elif [ -x "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ]; then
+  CODE="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+elif [ -x "$HOME/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ]; then
+  CODE="$HOME/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+else
+  echo "ERROR: Could not find the 'code' CLI."
+  echo "Fix: Open VS Code → Command Palette → 'Shell Command: Install code command in PATH'"
+  exit 1
+fi
+
+cd "$ROOT"
+
+echo "==> Building..."
+npm run build
+
+# On Apple Silicon Macs, the user's Node may be x64 (Rosetta) while VS Code runs
+# as arm64.  Native modules (better-sqlite3, sqlite-vec) must match VS Code's arch.
+if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
+  NODE_ARCH=$(node -p "process.arch")
+  if [[ "$NODE_ARCH" == "x64" ]]; then
+    echo "==> Detected x64 Node on arm64 Mac — rebuilding native modules for arm64..."
+
+    # Re-fetch the arm64 prebuilt binary for better-sqlite3
+    cd node_modules/better-sqlite3
+    npx prebuild-install -r napi --arch arm64 || node-gyp rebuild --release --arch=arm64
+    cd "$ROOT"
+
+    # Ensure the arm64 sqlite-vec optional dependency is present
+    npm install --no-save sqlite-vec-darwin-arm64 2>/dev/null || true
+  fi
+fi
+
+echo "==> Packaging VSIX..."
+npx vsce package --out repolens-dev.vsix
+
+echo "==> Installing extension..."
+"$CODE" --install-extension repolens-dev.vsix --force
+
+echo "==> Opening new VS Code window..."
+"$CODE" --new-window .
+
+echo ""
+echo "Done. To view logs:"
+echo "  VS Code → View → Output → select 'RepoLens' from the dropdown"
+echo "  Or set repoLens.log.level to 'debug' in settings for verbose output"

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -30,7 +30,7 @@ export class ConfigManager implements vscode.Disposable {
     try {
       const raw = fs.readFileSync(this.configPath, 'utf-8');
       return JSON.parse(raw) as RepoLensConfig;
-    } catch (err) {
+    } catch {
       // If the file exists but is corrupt, back it up
       if (fs.existsSync(this.configPath)) {
         const backupPath = this.configPath + '.bak';


### PR DESCRIPTION
## Summary
- Removed `node_modules/**` from `.vscodeignore` so production dependencies (including native modules) are bundled into the VSIX
- `dev-install.sh` now detects x64 Node running under Rosetta on arm64 Macs and rebuilds `better-sqlite3` and `sqlite-vec` for arm64 before packaging
- CI (`_build.yml`) now builds platform-specific VSIXs via a matrix (linux-x64, darwin-arm64, darwin-x64) instead of a single `--no-dependencies` build
- Release and prerelease workflows download all platform VSIXs and attach them to the GitHub release

## Test plan
- [ ] Run `npm run dev:install` on an Apple Silicon Mac (with x64 Node under Rosetta) and verify the extension activates without dlopen errors
- [ ] Run `npm run dev:install` on an Apple Silicon Mac with native arm64 Node and verify it still works
- [ ] Verify CI matrix builds pass for all three targets
- [ ] Tag a prerelease and confirm all three VSIXs are attached to the GitHub release

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)