### PR TITLE
feat: dynamically register LM tools when tools are added/removed in config

### DIFF
--- a/src/tools/toolManager.ts
+++ b/src/tools/toolManager.ts
@@ -20,6 +20,7 @@ export class ToolManager implements vscode.Disposable {
 
   registerAll(): void {
     this.registerGlobalSearchTool();
+    this.syncRegistrations();
   }
 
   private registerGlobalSearchTool(): void {
@@ -39,7 +40,43 @@ export class ToolManager implements vscode.Disposable {
   }
 
   private syncRegistrations(): void {
-    // No-op: only the static global search tool is registered
+    const configTools = this.configManager.getTools();
+    const desiredNames = new Set(
+      configTools.map((t) => this.registrationName(t.name)),
+    );
+
+    // Unregister tools no longer in config
+    for (const [key, disposable] of this.registeredTools) {
+      if (key === '__global__') continue;
+      if (!desiredNames.has(key)) {
+        disposable.dispose();
+        this.registeredTools.delete(key);
+        this.logger.info(`Unregistered tool: ${key}`);
+      }
+    }
+
+    // Register new tools from config
+    for (const tool of configTools) {
+      const name = this.registrationName(tool.name);
+      if (!this.registeredTools.has(name)) {
+        const toolId = tool.id;
+        const disposable = vscode.lm.registerTool(name, {
+          invoke: async (options, token) => {
+            return this.toolHandler.handle(
+              toolId,
+              options as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
+              token,
+            );
+          },
+        });
+        this.registeredTools.set(name, disposable);
+        this.logger.info(`Registered tool: ${name}`);
+      }
+    }
+  }
+
+  private registrationName(toolName: string): string {
+    return `repolens-${toolName}`;
   }
 
   dispose(): void {

--- a/test/unit/tools/toolManager.test.ts
+++ b/test/unit/tools/toolManager.test.ts
@@ -66,14 +66,14 @@ describe('ToolManager', () => {
     manager.dispose();
   });
 
-  it('registerAll only registers the global search tool', () => {
+  it('registerAll registers config tools alongside global tool', () => {
     configTools = [makeTool('t-1', 'my-tool'), makeTool('t-2', 'other-tool')];
     const manager = new ToolManager(configManager, toolHandler, logger);
     manager.registerAll();
 
     expect(registeredTools.has('repolens-search')).toBe(true);
-    expect(registeredTools.has('repolens-my-tool')).toBe(false);
-    expect(registeredTools.has('repolens-other-tool')).toBe(false);
+    expect(registeredTools.has('repolens-my-tool')).toBe(true);
+    expect(registeredTools.has('repolens-other-tool')).toBe(true);
     manager.dispose();
   });
 
@@ -88,26 +88,44 @@ describe('ToolManager', () => {
     expect(globalDisposals.length).toBe(1);
   });
 
-  it('syncRegistrations is a no-op for config changes', () => {
+  it('syncRegistrations registers new tools on config change', () => {
     const manager = new ToolManager(configManager, toolHandler, logger);
     manager.registerAll();
 
-    // Simulate config change — should not register new tools
+    // Simulate config change — should register new tool
     configTools = [makeTool('t-new', 'new-tool')];
     changeListeners.forEach((cb) => cb());
 
-    expect(registeredTools.has('repolens-new-tool')).toBe(false);
+    expect(registeredTools.has('repolens-new-tool')).toBe(true);
     expect(registeredTools.has('repolens-search')).toBe(true);
     manager.dispose();
   });
 
-  it('dispose cleans up all registered tools', () => {
+  it('syncRegistrations unregisters removed tools', () => {
+    configTools = [makeTool('t-1', 'my-tool')];
+    const manager = new ToolManager(configManager, toolHandler, logger);
+    manager.registerAll();
+
+    expect(registeredTools.has('repolens-my-tool')).toBe(true);
+
+    // Remove tool from config
+    configTools = [];
+    changeListeners.forEach((cb) => cb());
+
+    expect(registeredTools.has('repolens-my-tool')).toBe(false);
+    expect(disposedTools).toContain('repolens-my-tool');
+    manager.dispose();
+  });
+
+  it('dispose cleans up all registered tools including config tools', () => {
+    configTools = [makeTool('t-1', 'my-tool')];
     const manager = new ToolManager(configManager, toolHandler, logger);
     manager.registerAll();
 
     manager.dispose();
 
     expect(disposedTools).toContain('repolens-search');
+    expect(disposedTools).toContain('repolens-my-tool');
   });
 
   it('keeps global tool during syncRegistrations', () => {
@@ -121,6 +139,51 @@ describe('ToolManager', () => {
     // Global tool should still be registered
     expect(registeredTools.has('repolens-search')).toBe(true);
     expect(disposedTools).not.toContain('repolens-search');
+    manager.dispose();
+  });
+
+  it('registered config tool invokes toolHandler.handle with correct id', async () => {
+    configTools = [makeTool('t-1', 'my-tool')];
+    const manager = new ToolManager(configManager, toolHandler, logger);
+    manager.registerAll();
+
+    const handler = registeredTools.get('repolens-my-tool');
+    const mockOptions = { input: { query: 'test' } };
+    const mockToken = { isCancellationRequested: false };
+
+    await handler.invoke(mockOptions, mockToken);
+
+    expect(toolHandler.handle).toHaveBeenCalledWith('t-1', mockOptions, mockToken);
+    manager.dispose();
+  });
+
+  it('does not re-register unchanged tools on config change', () => {
+    configTools = [makeTool('t-1', 'my-tool')];
+    const manager = new ToolManager(configManager, toolHandler, logger);
+    manager.registerAll();
+
+    // Trigger config change with same tools
+    changeListeners.forEach((cb) => cb());
+
+    // Should not have been disposed and re-registered
+    expect(disposedTools).not.toContain('repolens-my-tool');
+    manager.dispose();
+  });
+
+  it('handles tool replacement when name changes', () => {
+    configTools = [makeTool('t-1', 'old-name')];
+    const manager = new ToolManager(configManager, toolHandler, logger);
+    manager.registerAll();
+
+    expect(registeredTools.has('repolens-old-name')).toBe(true);
+
+    // Simulate name change
+    configTools = [makeTool('t-1', 'new-name')];
+    changeListeners.forEach((cb) => cb());
+
+    expect(registeredTools.has('repolens-old-name')).toBe(false);
+    expect(registeredTools.has('repolens-new-name')).toBe(true);
+    expect(disposedTools).toContain('repolens-old-name');
     manager.dispose();
   });
 });


### PR DESCRIPTION
ToolManager.syncRegistrations() now diffs config tools against registered
tools on every config change, calling vscode.lm.registerTool for new tools
and disposing removed ones. Tools are immediately available to Copilot Chat.

https://claude.ai/code/session_01YXuqwged342mDR2UqZXRdg