### PR TITLE
Add repolens-get-file tool for fetching full file content from GitHub

### DIFF
--- a/docs/design-get-file-tool.md
+++ b/docs/design-get-file-tool.md
@@ -1,0 +1,122 @@
+# Get File Tool — Design Document
+
+## 1. Where registration lives
+
+The feature follows the same three-layer pattern as `repolens-search`.
+
+**`src/tools/getFileTool.ts`**
+Exports a `GET_FILE_TOOL` constant (name, displayName, description, inputSchema),
+mirroring `globalSearchTool.ts`. Single source of truth for the tool's identity;
+`package.json` and `ToolManager` both reference the same name string.
+
+**`src/tools/toolHandler.ts`**
+New public method `handleGetFile()` added to the existing `ToolHandler` class.
+`GitHubFetcher` is added as a constructor parameter. `extension.ts` already holds
+`fetcher` and passes it at construction time.
+
+**`src/tools/toolManager.ts`**
+New private method `registerGetFileTool()`, called from `registerAll()` alongside
+`registerGlobalSearchTool()`. Stored under the key `'__getfile__'` in
+`registeredTools`. Registration is static (global, always-on) — no per-tool
+config entry needed.
+
+**`package.json`**
+New entry appended to `contributes.languageModelTools`.
+
+**`src/extension.ts`**
+Pass `fetcher` as a new argument to the `ToolHandler` constructor.
+
+---
+
+## 2. How the repository input maps to the GitHub client and branch
+
+The input parameter is named `repository` and accepts `owner/repo` format,
+matching what `ContextBuilder.format()` already surfaces to the model in search
+results. The spec's UUID `repoId` was not adopted — the model has no UUID from
+search output.
+
+Resolution:
+
+```typescript
+const ds = configManager.getDataSources()
+  .find(ds => `${ds.owner}/${ds.repo}`.toLowerCase() === input.repository.toLowerCase());
+```
+
+`DataSourceConfig.branch` provides the branch. `GitHubFetcher` carries the
+authenticated token in its `getToken` closure — one fetcher instance handles
+all repos.
+
+**New method on `GitHubFetcher`: `getFileContents()`**
+
+`getBlob()` requires a SHA. The Contents API accepts a path + branch ref:
+
+```
+GET /repos/{owner}/{repo}/contents/{path}?ref={branch}
+Accept: application/vnd.github.raw+json
+```
+
+Path segments are each `encodeURIComponent`-encoded; slashes are preserved.
+Rate limit tracking follows the same `updateRateLimit()` / `waitForRateLimit()`
+pattern already in `GitHubFetcher`.
+
+---
+
+## 3. Response format
+
+```
+**owner/repo** · Branch: `main` · `src/path/to/file.ts`
+Lines 1–320 of 320
+
+```ts
+... file content ...
+```
+```
+
+- Header gives repo, branch, and path — everything needed to cite the source
+- `Lines X–Y of N` tells the model the exact range received and total file size
+- Language hint inferred from file extension for the fenced code block
+- When the full file fits within limits, `Lines 1–N of N` with no truncation notice
+
+---
+
+## 4. Large file truncation
+
+- Default limits: **3,000 lines** or **80,000 characters**, whichever is hit first
+- **No range given, file exceeds limit:** return lines 1–N, append a plain-text
+  notice after the code block:
+  ```
+  [File truncated — showing lines 1–3000 of 8400. Call again with startLine/endLine to fetch a specific range.]
+  ```
+- **Range given (`startLine`/`endLine`):** slice to exactly that range, no
+  truncation applied, no notice appended
+- All line numbers in the response are 1-indexed actual file line numbers
+
+---
+
+## 5. Error handling
+
+All errors return as `LanguageModelTextPart` text inside a
+`LanguageModelToolResult`, matching the catch-and-return pattern in
+`executeSearch()`. The model can reason about every case.
+
+| Condition | Text returned to model |
+|---|---|
+| `repository` not matched | `Repository "owner/repo" is not indexed. Indexed repositories: a/b, c/d` |
+| GitHub 404 | `File "src/foo.ts" was not found in owner/repo on branch "main". The path may have changed since the last index.` |
+| GitHub 401/403 | `Cannot access owner/repo: insufficient token permissions.` |
+| Rate limit | Reused from `waitForRateLimit()`: `GitHub API rate limit exceeded. Try again after {ISO timestamp}.` |
+| Any other error | `Get File failed: {err.message}` |
+
+---
+
+## 6. Edge cases
+
+- **Binary files:** No extension check at fetch time. If the GitHub API returns
+  binary content, the model receives raw bytes in a code block. This is
+  acceptable for v1 — the model will recognise the output as non-text.
+- **Status guard:** No `status === 'ready'` check applied. Content is fetched
+  live from GitHub regardless of index state; the repo's `{ owner, repo, branch }`
+  is all that's needed.
+- **Invalid line range:** If `startLine > endLine` or the range exceeds the file,
+  the slice returns an empty or partial result. No validation error — the response
+  naturally communicates what was returned via the `Lines X–Y of N` header.

--- a/package.json
+++ b/package.json
@@ -189,6 +189,36 @@
           },
           "required": ["query"]
         }
+      },
+      {
+        "name": "repolens-get-file",
+        "toolReferenceName": "repolensGetFile",
+        "tags": ["repolens", "github", "file", "code"],
+        "displayName": "RepoLens: Get File",
+        "userDescription": "Fetch the full content of a file from an indexed GitHub repository.",
+        "modelDescription": "Fetch the full or partial content of a file from an indexed GitHub repository. Use this when search results reference a file and you need more context than the returned chunk provides. Provide startLine and endLine to fetch a specific section of a large file.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "The indexed repository in 'owner/repo' format (e.g. 'vercel/next.js'). Use the repository shown in search results."
+            },
+            "filePath": {
+              "type": "string",
+              "description": "Path to the file within the repository, as shown in search results."
+            },
+            "startLine": {
+              "type": "number",
+              "description": "Optional. First line to return (1-indexed). Use line numbers from search results."
+            },
+            "endLine": {
+              "type": "number",
+              "description": "Optional. Last line to return (1-indexed). Use line numbers from search results."
+            }
+          },
+          "required": ["repository", "filePath"]
+        }
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,6 +83,7 @@ export function activate(context: vscode.ExtensionContext): void {
     providerRegistry,
     retriever,
     contextBuilder,
+    fetcher,
   );
   const toolManager = new ToolManager(configManager, toolHandler, logger);
   toolManager.registerAll();

--- a/src/sources/github/githubFetcher.ts
+++ b/src/sources/github/githubFetcher.ts
@@ -122,6 +122,37 @@ export class GitHubFetcher {
     return results;
   }
 
+  async getFileContents(owner: string, repo: string, path: string, branch: string): Promise<string> {
+    await this.waitForRateLimit();
+    const token = await this.getToken();
+    const encodedPath = path.split('/').map(enc).join('/');
+    const res = await fetch(
+      `${GITHUB_API}/repos/${enc(owner)}/${enc(repo)}/contents/${encodedPath}?ref=${enc(branch)}`,
+      {
+        headers: {
+          ...githubHeaders(token),
+          Accept: 'application/vnd.github.raw+json',
+        },
+      },
+    );
+    this.updateRateLimit(res);
+
+    if (!res.ok) {
+      if (res.status === 404) {
+        throw new Error(
+          `File "${path}" was not found in ${owner}/${repo} on branch "${branch}". ` +
+          `The path may have changed since the last index.`,
+        );
+      }
+      if (res.status === 401 || res.status === 403) {
+        throw new Error(`Cannot access ${owner}/${repo}: insufficient token permissions.`);
+      }
+      throw new Error(`GitHub API error ${res.status}: ${res.statusText}`);
+    }
+
+    return res.text();
+  }
+
   async getBranchSha(owner: string, repo: string, branch: string): Promise<string> {
     const token = await this.getToken();
     const res = await fetch(

--- a/src/tools/getFileTool.ts
+++ b/src/tools/getFileTool.ts
@@ -1,0 +1,37 @@
+// Get File tool metadata.
+// Registration is handled by ToolManager. This module defines the
+// tool description used for Copilot discovery.
+
+export const GET_FILE_TOOL = {
+  name: 'repolens-get-file',
+  displayName: 'RepoLens: Get File',
+  description:
+    'Fetch the full content of a file from an indexed GitHub repository. ' +
+    'Use this when search results reference a file and you need more context ' +
+    'than the returned chunk provides. Provide startLine and endLine to fetch ' +
+    'a specific section of a large file.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      repository: {
+        type: 'string' as const,
+        description:
+          "The indexed repository in 'owner/repo' format (e.g. 'vercel/next.js'). " +
+          'Use the repository shown in search results.',
+      },
+      filePath: {
+        type: 'string' as const,
+        description: 'Path to the file within the repository, as shown in search results.',
+      },
+      startLine: {
+        type: 'number' as const,
+        description: 'Optional. First line to return (1-indexed). Use line numbers from search results.',
+      },
+      endLine: {
+        type: 'number' as const,
+        description: 'Optional. Last line to return (1-indexed). Use line numbers from search results.',
+      },
+    },
+    required: ['repository', 'filePath'],
+  },
+};

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -3,7 +3,11 @@ import { ConfigManager } from '../config/configManager';
 import { EmbeddingProviderRegistry } from '../embedding/registry';
 import { Retriever } from '../retrieval/retriever';
 import { ContextBuilder } from '../retrieval/contextBuilder';
+import { GitHubFetcher } from '../sources/github/githubFetcher';
 import { SETTING_KEYS } from '../config/settingsSchema';
+
+const MAX_LINES = 3000;
+const MAX_CHARS = 80_000;
 
 export class ToolHandler {
   constructor(
@@ -11,6 +15,7 @@ export class ToolHandler {
     private readonly providerRegistry: EmbeddingProviderRegistry,
     private readonly retriever: Retriever,
     private readonly contextBuilder: ContextBuilder,
+    private readonly fetcher: GitHubFetcher,
   ) {}
 
   async handle(
@@ -74,6 +79,84 @@ export class ToolHandler {
     return this.executeSearch(options.input.query, targetIds, searchedRepos);
   }
 
+  async handleGetFile(
+    options: vscode.LanguageModelToolInvocationOptions<{
+      repository: string;
+      filePath: string;
+      startLine?: number;
+      endLine?: number;
+    }>,
+    _token: vscode.CancellationToken,
+  ): Promise<vscode.LanguageModelToolResult> {
+    const { repository, filePath, startLine, endLine } = options.input;
+
+    const ds = this.configManager
+      .getDataSources()
+      .find((s) => `${s.owner}/${s.repo}`.toLowerCase() === repository.toLowerCase());
+
+    if (!ds) {
+      const available = this.configManager
+        .getDataSources()
+        .map((s) => `${s.owner}/${s.repo}`)
+        .join(', ') || 'none';
+      return new vscode.LanguageModelToolResult([
+        new vscode.LanguageModelTextPart(
+          `Repository "${repository}" is not indexed. Indexed repositories: ${available}`,
+        ),
+      ]);
+    }
+
+    try {
+      const raw = await this.fetcher.getFileContents(ds.owner, ds.repo, filePath, ds.branch);
+      const lines = raw.split('\n');
+      const totalLines = lines.length;
+
+      let sliced: string[];
+      let rangeStart: number;
+      let rangeEnd: number;
+      let truncated = false;
+
+      if (startLine !== undefined && endLine !== undefined) {
+        rangeStart = Math.max(1, startLine);
+        rangeEnd = Math.min(totalLines, endLine);
+        sliced = lines.slice(rangeStart - 1, rangeEnd);
+      } else {
+        rangeStart = 1;
+        let charCount = 0;
+        let cutAt = lines.length;
+        for (let i = 0; i < lines.length; i++) {
+          charCount += lines[i].length + 1;
+          if (i + 1 === MAX_LINES || charCount >= MAX_CHARS) {
+            cutAt = i + 1;
+            break;
+          }
+        }
+        truncated = cutAt < totalLines;
+        sliced = lines.slice(0, cutAt);
+        rangeEnd = cutAt;
+      }
+
+      const lang = langHint(filePath);
+      const header =
+        `**${ds.owner}/${ds.repo}** · Branch: \`${ds.branch}\` · \`${filePath}\`\n` +
+        `Lines ${rangeStart}–${rangeEnd} of ${totalLines}`;
+      const body = `\`\`\`${lang}\n${sliced.join('\n')}\n\`\`\``;
+      const notice = truncated
+        ? `\n[File truncated — showing lines 1–${rangeEnd} of ${totalLines}. ` +
+          `Call again with startLine/endLine to fetch a specific range.]`
+        : '';
+
+      return new vscode.LanguageModelToolResult([
+        new vscode.LanguageModelTextPart(`${header}\n\n${body}${notice}`),
+      ]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return new vscode.LanguageModelToolResult([
+        new vscode.LanguageModelTextPart(message),
+      ]);
+    }
+  }
+
   private async executeSearch(
     query: string,
     dataSourceIds: string[],
@@ -102,4 +185,20 @@ export class ToolHandler {
       ]);
     }
   }
+}
+
+function langHint(filePath: string): string {
+  const dot = filePath.lastIndexOf('.');
+  if (dot === -1) return '';
+  const ext = filePath.slice(dot + 1).toLowerCase();
+  const map: Record<string, string> = {
+    ts: 'ts', tsx: 'tsx', js: 'js', jsx: 'jsx', mjs: 'js', cjs: 'js',
+    py: 'py', rb: 'rb', go: 'go', rs: 'rs',
+    java: 'java', kt: 'kt', cs: 'cs', cpp: 'cpp', c: 'c', h: 'h',
+    json: 'json', yaml: 'yaml', yml: 'yaml', toml: 'toml',
+    md: 'md', html: 'html', css: 'css', scss: 'scss',
+    sh: 'sh', bash: 'sh', zsh: 'sh',
+    sql: 'sql', graphql: 'graphql',
+  };
+  return map[ext] ?? '';
 }

--- a/src/tools/toolManager.ts
+++ b/src/tools/toolManager.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ConfigManager } from '../config/configManager';
 import { ToolHandler } from './toolHandler';
+import { GET_FILE_TOOL } from './getFileTool';
 import { Logger } from '../util/logger';
 
 export class ToolManager implements vscode.Disposable {
@@ -20,6 +21,7 @@ export class ToolManager implements vscode.Disposable {
 
   registerAll(): void {
     this.registerGlobalSearchTool();
+    this.registerGetFileTool();
     this.syncRegistrations();
   }
 
@@ -39,6 +41,27 @@ export class ToolManager implements vscode.Disposable {
     this.logger.info('Registered global search tool');
   }
 
+  private registerGetFileTool(): void {
+    if (this.registeredTools.has('__getfile__')) return;
+
+    const disposable = vscode.lm.registerTool(GET_FILE_TOOL.name, {
+      invoke: async (options, token) => {
+        return this.toolHandler.handleGetFile(
+          options as vscode.LanguageModelToolInvocationOptions<{
+            repository: string;
+            filePath: string;
+            startLine?: number;
+            endLine?: number;
+          }>,
+          token,
+        );
+      },
+    });
+
+    this.registeredTools.set('__getfile__', disposable);
+    this.logger.info('Registered get file tool');
+  }
+
   private syncRegistrations(): void {
     const configTools = this.configManager.getTools();
     const desiredNames = new Set(
@@ -47,7 +70,7 @@ export class ToolManager implements vscode.Disposable {
 
     // Unregister tools no longer in config
     for (const [key, disposable] of this.registeredTools) {
-      if (key === '__global__') continue;
+      if (key === '__global__' || key === '__getfile__') continue;
       if (!desiredNames.has(key)) {
         disposable.dispose();
         this.registeredTools.delete(key);


### PR DESCRIPTION
Registers a new global LM tool alongside repolens-search that lets the
model fetch full or partial file content live from the GitHub Contents API.
Accepts owner/repo format (matching search output), optional startLine/endLine
for targeted fetches, and truncates at 3000 lines / 80K chars with a clear
notice the model can act on.

https://claude.ai/code/session_01VRrBs2z2A5Zv7NNYMQySAU