### PR TITLE
Rename project from RepoLens to Yoink

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,6 +17,6 @@ tsconfig.json
 vitest.config.ts
 eslint.config.mjs
 esbuild.mjs
-repolens.json.schema.json
+yoink.json.schema.json
 ARCHITECTURE.md
 CLAUDE.md

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,17 +1,17 @@
-# RepoLens Architecture
+# Yoink Architecture
 
 ## 1. Folder & Module Structure
 
 ```
-repolens/
+yoink/
 ├── package.json                  # Extension manifest, contributes, activation events
 ├── tsconfig.json
-├── repolens.json.schema.json     # JSON Schema for repolens.json config file
+├── yoink.json.schema.json     # JSON Schema for yoink.json config file
 ├── src/
 │   ├── extension.ts              # activate() / deactivate() — wires everything
 │   │
 │   ├── config/
-│   │   ├── configManager.ts      # Read/write/watch repolens.json
+│   │   ├── configManager.ts      # Read/write/watch yoink.json
 │   │   ├── configSchema.ts       # TypeScript types for config file
 │   │   └── settingsSchema.ts     # VS Code settings type definitions
 │   │
@@ -112,7 +112,7 @@ interface DataSourceConfig {
 }
 ```
 
-`DataSourceManager` owns the lifecycle: create, update, delete, trigger sync. It writes config changes to `repolens.json` and coordinates with the ingestion pipeline.
+`DataSourceManager` owns the lifecycle: create, update, delete, trigger sync. It writes config changes to `yoink.json` and coordinates with the ingestion pipeline.
 
 ### Tool
 
@@ -168,7 +168,7 @@ For markdown/docs: same strategy works well since prose is less structure-depend
 ### Adding a Repository (end-to-end)
 
 ```
-User invokes "RepoLens: Add Repository"
+User invokes "Yoink: Add Repository"
   │
   ▼
 ┌─────────────────────┐
@@ -180,7 +180,7 @@ User invokes "RepoLens: Add Repository"
          ▼
 ┌─────────────────────┐
 │  configManager.ts   │  Write DataSourceConfig + ToolConfig
-│                     │  to repolens.json
+│                     │  to yoink.json
 └────────┬────────────┘
          │
          ▼  (event emitted)
@@ -256,9 +256,9 @@ VS Code's Chat Tools API (`vscode.lm` namespace) allows extensions to register t
 In `extension.ts` → `activate()`:
 
 ```typescript
-// For each tool in repolens.json config:
+// For each tool in yoink.json config:
 const disposable = vscode.lm.registerTool(
-  `repolens.${tool.name}`,   // tool ID (namespaced)
+  `yoink.${tool.name}`,   // tool ID (namespaced)
   {
     // The tool implementation
     invoke: async (options, token) => {
@@ -286,12 +286,12 @@ const disposable = vscode.lm.registerTool(
 Always registered, searches across all indexed data sources:
 
 ```typescript
-vscode.lm.registerTool('repolens.search', {
+vscode.lm.registerTool('yoink.search', {
   invoke: async (options, token) => {
     // Query all data sources, no scoping
     return toolHandler.handleGlobalSearch(options, token);
   },
-  displayName: 'RepoLens Search',
+  displayName: 'Yoink Search',
   description: 'Search across all configured repository knowledge bases',
   inputSchema: { /* same as above */ }
 });
@@ -333,7 +333,7 @@ CREATE TABLE meta (
   value TEXT NOT NULL
 );
 
--- Tracks configured data sources (mirrors repolens.json for query joins)
+-- Tracks configured data sources (mirrors yoink.json for query joins)
 CREATE TABLE data_sources (
   id                TEXT PRIMARY KEY,     -- UUID
   owner             TEXT NOT NULL,
@@ -408,9 +408,9 @@ LIMIT 10;
 
 ---
 
-## 6. Config File Schema (`repolens.json`)
+## 6. Config File Schema (`yoink.json`)
 
-Stored at `{globalStorageUri}/repolens.json`.
+Stored at `{globalStorageUri}/yoink.json`.
 
 ```jsonc
 {
@@ -468,35 +468,35 @@ Contributed via `package.json` → `contributes.configuration`:
 
 ```jsonc
 {
-  "repoLens.embedding.provider": {
+  "yoink.embedding.provider": {
     "type": "string",
     "enum": ["openai"],
     "default": "openai",
     "description": "Embedding provider to use for indexing."
   },
-  "repoLens.embedding.openai.model": {
+  "yoink.embedding.openai.model": {
     "type": "string",
     "default": "text-embedding-3-small",
     "description": "OpenAI embedding model to use."
   },
-  "repoLens.embedding.openai.baseUrl": {
+  "yoink.embedding.openai.baseUrl": {
     "type": "string",
     "default": "https://api.openai.com/v1",
     "description": "Base URL for OpenAI-compatible API (for proxies or compatible services)."
   },
-  "repoLens.search.topK": {
+  "yoink.search.topK": {
     "type": "number",
     "default": 10,
     "minimum": 1,
     "maximum": 50,
     "description": "Number of chunks to return per tool query."
   },
-  "repoLens.sync.onStartup": {
+  "yoink.sync.onStartup": {
     "type": "boolean",
     "default": true,
     "description": "Automatically sync data sources marked 'onStartup' when VS Code launches."
   },
-  "repoLens.log.level": {
+  "yoink.log.level": {
     "type": "string",
     "enum": ["debug", "info", "warn", "error"],
     "default": "info",
@@ -512,7 +512,7 @@ Contributed via `package.json` → `contributes.configuration`:
 ### 1. API key storage → SecretStorage + env var fallback
 
 `vscode.SecretStorage` (OS keychain-backed) is the primary storage for API keys.
-A command "RepoLens: Set OpenAI API Key" writes to SecretStorage. The
+A command "Yoink: Set OpenAI API Key" writes to SecretStorage. The
 `${env:OPENAI_API_KEY}` environment variable is supported as fallback. Raw API
 keys are never stored in `settings.json`. Resolution order:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,22 +24,22 @@ npm run dev:install    # build + vsce package + code --install-extension + open 
 bash scripts/dev-install.sh
 ```
 
-This produces `repolens-dev.vsix`, installs it, and opens a new VS Code window. Use this whenever you want to manually test a change end-to-end.
+This produces `yoink-dev.vsix`, installs it, and opens a new VS Code window. Use this whenever you want to manually test a change end-to-end.
 
-**Viewing logs:** View → Output → select **RepoLens**. Set `repoLens.log.level = "debug"` in settings for verbose output.
+**Viewing logs:** View → Output → select **Yoink**. Set `yoink.log.level = "debug"` in settings for verbose output.
 
 ## Packaging and Local Install
 
 ```bash
 npm run build                                    # compile TypeScript first
-npm run package                                  # vsce package → repolens-0.0.1.vsix
-code --install-extension repolens-0.0.1.vsix     # install into VS Code
+npm run package                                  # vsce package → yoink-0.0.1.vsix
+code --install-extension yoink-0.0.1.vsix     # install into VS Code
 ```
 
 To uninstall:
 
 ```bash
-code --uninstall-extension repolens.repolens
+code --uninstall-extension yoink.yoink
 ```
 
 Dependencies (including native modules like `better-sqlite3` and `sqlite-vec`) are bundled into the VSIX. CI builds platform-specific VSIXs via `vsce package --target <platform>` on matching runners (linux-x64, darwin-arm64, darwin-x64).
@@ -59,7 +59,7 @@ The workflow (`.github/workflows/release.yml`) runs on any `v*` tag, builds for 
 
 ## Architecture Overview
 
-RepoLens is a VS Code extension that indexes GitHub repositories into a local SQLite vector database and exposes them as Copilot Chat tools.
+Yoink is a VS Code extension that indexes GitHub repositories into a local SQLite vector database and exposes them as Copilot Chat tools.
 
 ### Dependency Wiring
 
@@ -73,7 +73,7 @@ GitHub Trees API → fileFilter (glob) → GitHub Blobs API
   → OpenAI embedding API → better-sqlite3 (chunks + vec0)
 ```
 
-`src/ingestion/pipeline.ts` orchestrates this. A concurrent queue (limit: 3 parallel data sources) is managed inside the pipeline. Status transitions (`queued → indexing → ready | error`) are written to both the SQLite `data_sources` table and `repolens.json`.
+`src/ingestion/pipeline.ts` orchestrates this. A concurrent queue (limit: 3 parallel data sources) is managed inside the pipeline. Status transitions (`queued → indexing → ready | error`) are written to both the SQLite `data_sources` table and `yoink.json`.
 
 ### Query Path (read path)
 
@@ -89,19 +89,19 @@ Vector search is brute-force KNN via `sqlite-vec` (vec0 virtual table). Always s
 
 **`EmbeddingProvider`** (`src/embedding/embeddingProvider.ts`): Interface with `embed(texts)`, `dimensions`, and optional `countTokens()`. The registry (`src/embedding/registry.ts`) builds the concrete provider from VS Code settings. Changing providers requires dropping and recreating the `embeddings` vec0 table (different dimensions).
 
-**`DataSourceConfig`** (`src/config/configSchema.ts`): The canonical representation of a repo. Written to `{globalStorageUri}/repolens.json` by `ConfigManager`. Mirrored into the `data_sources` SQLite table for query joins.
+**`DataSourceConfig`** (`src/config/configSchema.ts`): The canonical representation of a repo. Written to `{globalStorageUri}/yoink.json` by `ConfigManager`. Mirrored into the `data_sources` SQLite table for query joins.
 
 **`ToolConfig`** (`src/config/configSchema.ts`): Each tool maps `dataSourceIds[]` → a `vscode.lm.registerTool()` call. `ToolManager` diffs config on every change event and re-registers as needed.
 
 ### Config Layering
 
 Two config systems coexist:
-- **`repolens.json`** (in `globalStorageUri`): user data — data sources, tools, sync state. Managed by `ConfigManager`, watched for external edits.
-- **VS Code settings** (`repoLens.*` in `package.json` `contributes.configuration`): operational settings — embedding provider, API base URL, log level, topK. Read via `vscode.workspace.getConfiguration()`.
+- **`yoink.json`** (in `globalStorageUri`): user data — data sources, tools, sync state. Managed by `ConfigManager`, watched for external edits.
+- **VS Code settings** (`yoink.*` in `package.json` `contributes.configuration`): operational settings — embedding provider, API base URL, log level, topK. Read via `vscode.workspace.getConfiguration()`.
 
 ### API Key Storage
 
-Resolution order: `SecretStorage` (OS keychain) → `OPENAI_API_KEY` env var → prompt user. Keys are never written to `settings.json` or `repolens.json`.
+Resolution order: `SecretStorage` (OS keychain) → `OPENAI_API_KEY` env var → prompt user. Keys are never written to `settings.json` or `yoink.json`.
 
 ### Delta Sync
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# RepoLens
+# Yoink
 
 Use any GitHub repository as RAG context for Copilot — query codebases, docs, and institutional knowledge without leaving VS Code.
 
-RepoLens indexes GitHub repositories into a local SQLite vector database and exposes them as Copilot Chat tools. Point it at any repo, ask Copilot a question, and it retrieves the most relevant chunks to ground the answer.
+Yoink indexes GitHub repositories into a local SQLite vector database and exposes them as Copilot Chat tools. Point it at any repo, ask Copilot a question, and it retrieves the most relevant chunks to ground the answer.
 
 ## Features
 
@@ -20,19 +20,19 @@ RepoLens indexes GitHub repositories into a local SQLite vector database and exp
 
 ## Setup
 
-1. Install the extension (see [Installing Locally](#installing-locally) or grab a release VSIX from [Releases](https://github.com/colbymk97/repo-lens/releases))
-2. Run **RepoLens: Set OpenAI API Key** from the command palette
-3. Open the RepoLens sidebar and add a repository
+1. Install the extension (see [Installing Locally](#installing-locally) or grab a release VSIX from [Releases](https://github.com/colbymk97/yoink/releases))
+2. Run **Yoink: Set OpenAI API Key** from the command palette
+3. Open the Yoink sidebar and add a repository
 4. Wait for indexing to complete, then ask Copilot about it
 
 ## Installing Locally
 
 ### From a release VSIX
 
-Download the `.vsix` file from the [Releases](https://github.com/colbymk97/repo-lens/releases) page, then:
+Download the `.vsix` file from the [Releases](https://github.com/colbymk97/yoink/releases) page, then:
 
 ```bash
-code --install-extension repolens-0.0.1.vsix
+code --install-extension yoink-0.0.1.vsix
 ```
 
 Or via the VS Code UI: Extensions panel → `...` menu → **Install from VSIX...**
@@ -40,30 +40,30 @@ Or via the VS Code UI: Extensions panel → `...` menu → **Install from VSIX..
 ### Build and install from source
 
 ```bash
-git clone https://github.com/colbymk97/repo-lens.git
+git clone https://github.com/colbymk97/yoink.git
 cd Lens
 npm install
 npm run build
-npm run package        # produces repolens-0.0.1.vsix in the project root
-code --install-extension repolens-0.0.1.vsix
+npm run package        # produces yoink-0.0.1.vsix in the project root
+code --install-extension yoink-0.0.1.vsix
 ```
 
 To uninstall:
 
 ```bash
-code --uninstall-extension repolens.repolens
+code --uninstall-extension yoink.yoink
 ```
 
 ## Extension Settings
 
 | Setting | Default | Description |
 |---|---|---|
-| `repoLens.embedding.provider` | `openai` | Embedding provider |
-| `repoLens.embedding.openai.model` | `text-embedding-3-small` | OpenAI embedding model |
-| `repoLens.embedding.openai.baseUrl` | `https://api.openai.com/v1` | Base URL (supports compatible proxies) |
-| `repoLens.search.topK` | `10` | Chunks returned per query |
-| `repoLens.sync.onStartup` | `true` | Auto-sync on VS Code launch |
-| `repoLens.log.level` | `info` | Log verbosity (`debug` / `info` / `warn` / `error`) |
+| `yoink.embedding.provider` | `openai` | Embedding provider |
+| `yoink.embedding.openai.model` | `text-embedding-3-small` | OpenAI embedding model |
+| `yoink.embedding.openai.baseUrl` | `https://api.openai.com/v1` | Base URL (supports compatible proxies) |
+| `yoink.search.topK` | `10` | Chunks returned per query |
+| `yoink.sync.onStartup` | `true` | Auto-sync on VS Code launch |
+| `yoink.log.level` | `info` | Log verbosity (`debug` / `info` / `warn` / `error`) |
 
 ## Development
 
@@ -80,11 +80,11 @@ npm run dev:install    # Build, install, and open a new VS Code window
 
 ### Viewing logs
 
-RepoLens writes to a VS Code Output Channel. To open it:
+Yoink writes to a VS Code Output Channel. To open it:
 
-**View → Output**, then select **RepoLens** from the dropdown in the top-right of the panel.
+**View → Output**, then select **Yoink** from the dropdown in the top-right of the panel.
 
-To enable verbose logging, set `repoLens.log.level` to `"debug"` in your VS Code settings — this surfaces chunking, embedding, and sync details.
+To enable verbose logging, set `yoink.log.level` to `"debug"` in your VS Code settings — this surfaces chunking, embedding, and sync details.
 
 ## CI and Releases
 
@@ -105,7 +105,7 @@ git tag v0.0.1-alpha.1
 git push origin v0.0.1-alpha.1
 ```
 
-The VSIX will be attached to the GitHub release automatically. Download it from the [Releases](https://github.com/colbymk97/repo-lens/releases) page to test.
+The VSIX will be attached to the GitHub release automatically. Download it from the [Releases](https://github.com/colbymk97/yoink/releases) page to test.
 
 ### Publishing a stable release
 

--- a/docs/SLICES.md
+++ b/docs/SLICES.md
@@ -1,6 +1,6 @@
-# RepoLens — Implementation Slices
+# Yoink — Implementation Slices
 
-This document breaks the RepoLens architecture into ordered implementation
+This document breaks the Yoink architecture into ordered implementation
 slices. Each slice is vertically integrated — it produces something testable
 and builds on the previous slice. No slice should take more than a focused
 session to implement.
@@ -160,7 +160,7 @@ The first time the extension is actually useful.
    handler, verify formatted output
 
 **Acceptance:**
-- `repolens-search` tool is registered on activation
+- `yoink-search` tool is registered on activation
 - Querying the tool returns correctly formatted, ranked results
 - Adding/removing a tool in config triggers registration/disposal
 
@@ -174,7 +174,7 @@ The first time the extension is actually useful.
 full lifecycle from `activate()` to `deactivate()`.
 
 **Files:**
-- `src/config/configManager.ts` — read/write/watch `repolens.json`
+- `src/config/configManager.ts` — read/write/watch `yoink.json`
 - `src/config/configSchema.ts` — types + defaults
 - `src/extension.ts` — full dependency wiring
 
@@ -185,7 +185,7 @@ full lifecycle from `activate()` to `deactivate()`.
    resolution
 3. Register all disposables correctly — verify no resource leaks on
    deactivate
-4. Add config file watcher — if user edits `repolens.json` externally,
+4. Add config file watcher — if user edits `yoink.json` externally,
    reload and re-sync tool registrations
 5. Integration test: activate extension in VS Code Extension Test Host,
    verify tools register, config persists across activate/deactivate cycles
@@ -306,7 +306,7 @@ full lifecycle from `activate()` to `deactivate()`.
    file count / chunk count updates
 5. Duplicate prevention — prevent adding same owner/repo/branch twice
 6. Config corruption recovery — detect invalid JSON, offer to reset
-7. Logging — ensure all error paths log to the RepoLens output channel
+7. Logging — ensure all error paths log to the Yoink output channel
    with enough context to diagnose
 
 **Acceptance:**

--- a/docs/design-get-file-tool.md
+++ b/docs/design-get-file-tool.md
@@ -2,7 +2,7 @@
 
 ## 1. Where registration lives
 
-The feature follows the same three-layer pattern as `repolens-search`.
+The feature follows the same three-layer pattern as `yoink-search`.
 
 **`src/tools/getFileTool.ts`**
 Exports a `GET_FILE_TOOL` constant (name, displayName, description, inputSchema),

--- a/docs/design-repo-type-awareness.md
+++ b/docs/design-repo-type-awareness.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-RepoLens previously treated all indexed repos identically — same file filter
+Yoink previously treated all indexed repos identically — same file filter
 defaults, same chunking strategy, and the same generic tool description
 template. Different repo shapes (Actions libraries, documentation, CI/CD
 workflow repos, API specs) have radically different file structure and query

--- a/docs/design-shareable-config.md
+++ b/docs/design-shareable-config.md
@@ -1,12 +1,12 @@
 # Shareable Config — Design Document
 
-## 1. File Schema: `.vscode/repolens.json`
+## 1. File Schema: `.vscode/yoink.json`
 
-The shareable config is a strict subset of the internal `repolens.json`. It contains only the fields needed to reconstruct data sources and tools on another machine. All runtime state and credentials are stripped.
+The shareable config is a strict subset of the internal `yoink.json`. It contains only the fields needed to reconstruct data sources and tools on another machine. All runtime state and credentials are stripped.
 
 ```jsonc
 {
-  "$schema": "https://repolens.dev/schema/shareable-config.json",
+  "$schema": "https://yoink.dev/schema/shareable-config.json",
   "version": 1,
   "dataSources": [
     {
@@ -106,7 +106,7 @@ Detection runs once during `activate()`, after all core services are initialized
 
 ```
 1. Get workspace folders: vscode.workspace.workspaceFolders
-2. For each folder, check if {folder}/.vscode/repolens.json exists (fs.existsSync)
+2. For each folder, check if {folder}/.vscode/yoink.json exists (fs.existsSync)
 3. If found, parse the file and validate against ShareableConfig schema
 4. If valid, show a non-intrusive information message with "Import" and "Not Now" buttons
 5. If user clicks Import → run the merge algorithm
@@ -139,7 +139,7 @@ detector.detectAndPrompt();  // fire-and-forget (not awaited)
 
 ### Multi-root workspaces
 
-If multiple workspace folders contain `.vscode/repolens.json`, detect only the **first** one (primary workspace folder). This avoids conflicting prompts. The user can always import manually via the export/import commands if needed.
+If multiple workspace folders contain `.vscode/yoink.json`, detect only the **first** one (primary workspace folder). This avoids conflicting prompts. The user can always import manually via the export/import commands if needed.
 
 ### Re-prompt behavior
 
@@ -185,25 +185,25 @@ For each `ShareableTool` in the import:
 
 ### What the export command does
 
-1. Read the current `RepoLensConfig` from `ConfigManager`.
+1. Read the current `YoinkConfig` from `ConfigManager`.
 2. Map each `DataSourceConfig` to a `ShareableDataSource` by keeping only the shareable fields (see table in section 1). All runtime state fields (`id`, `status`, `lastSyncedAt`, `lastSyncCommitSha`, `errorMessage`) are dropped by construction — they simply aren't included in the output type.
 3. Map each `ToolConfig` to a `ShareableTool`:
    - Replace `dataSourceIds` (UUIDs) with `"owner/repo@branch"` strings by looking up each ID via `ConfigManager.getDataSource()`.
    - Skip any data source IDs that can't be resolved (orphaned references).
 4. Optionally include `defaultExcludePatterns` if they differ from the built-in defaults.
-5. Write the result as pretty-printed JSON to `{workspaceFolder}/.vscode/repolens.json`.
+5. Write the result as pretty-printed JSON to `{workspaceFolder}/.vscode/yoink.json`.
 
 ### What's inherently excluded
 
-The `repolens.json` config file **never contains secrets**. API keys are stored in VS Code's `SecretStorage` (OS keychain) or come from the `OPENAI_API_KEY` environment variable. GitHub tokens come from VS Code's built-in GitHub authentication provider. Neither appears in `repolens.json` at any point.
+The `yoink.json` config file **never contains secrets**. API keys are stored in VS Code's `SecretStorage` (OS keychain) or come from the `OPENAI_API_KEY` environment variable. GitHub tokens come from VS Code's built-in GitHub authentication provider. Neither appears in `yoink.json` at any point.
 
 So the export doesn't need to actively "strip" secrets — it just needs to avoid introducing any. The shareable schema has no fields for keys or tokens, making accidental inclusion structurally impossible.
 
 ### Export target
 
-- If a workspace folder is open, write to `{workspaceFolders[0]}/.vscode/repolens.json`.
-- If no workspace is open, show an error: *"Open a workspace folder first to export RepoLens config."*
-- If the file already exists, prompt: *"Overwrite existing .vscode/repolens.json?"* with Yes/No.
+- If a workspace folder is open, write to `{workspaceFolders[0]}/.vscode/yoink.json`.
+- If no workspace is open, show an error: *"Open a workspace folder first to export Yoink config."*
+- If the file already exists, prompt: *"Overwrite existing .vscode/yoink.json?"* with Yes/No.
 - Create the `.vscode/` directory if it doesn't exist.
 
 ---
@@ -226,6 +226,6 @@ So the export doesn't need to actively "strip" secrets — it just needs to avoi
 
 1. **Dismiss persistence**: Re-prompt each time. Simple, no persistence needed.
 2. **defaultExcludePatterns**: Only include in export if they differ from built-in defaults.
-3. **Manual import command**: Yes — "RepoLens: Import Config from Workspace" command added alongside auto-detect.
+3. **Manual import command**: Yes — "Yoink: Import Config from Workspace" command added alongside auto-detect.
 4. **Tool name collisions**: N/A — idempotent import skips duplicates silently.
 5. **Partial import failures**: Keep partial results, report what failed in the summary notification.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "repolens",
+  "name": "yoink",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "repolens",
+      "name": "yoink",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "repolens",
-  "displayName": "RepoLens",
+  "name": "yoink",
+  "displayName": "Yoink",
   "description": "Use any GitHub repository as RAG context for Copilot — query codebases, docs, and institutional knowledge without leaving VS Code.",
   "version": "0.0.1",
-  "publisher": "repolens",
+  "publisher": "yoink",
   "repository": {
     "type": "git",
-    "url": "https://github.com/colbymk97/repo-lens.git"
+    "url": "https://github.com/colbymk97/yoink.git"
   },
   "license": "MIT",
   "engines": {
@@ -30,68 +30,68 @@
   "contributes": {
     "commands": [
       {
-        "command": "repoLens.addRepository",
-        "title": "RepoLens: Add Repository"
+        "command": "yoink.addRepository",
+        "title": "Yoink: Add Repository"
       },
       {
-        "command": "repoLens.removeRepository",
-        "title": "RepoLens: Remove Repository"
+        "command": "yoink.removeRepository",
+        "title": "Yoink: Remove Repository"
       },
       {
-        "command": "repoLens.syncDataSource",
-        "title": "RepoLens: Sync Data Source"
+        "command": "yoink.syncDataSource",
+        "title": "Yoink: Sync Data Source"
       },
       {
-        "command": "repoLens.syncAllDataSources",
-        "title": "RepoLens: Sync All Data Sources"
+        "command": "yoink.syncAllDataSources",
+        "title": "Yoink: Sync All Data Sources"
       },
       {
-        "command": "repoLens.setApiKey",
-        "title": "RepoLens: Set OpenAI API Key"
+        "command": "yoink.setApiKey",
+        "title": "Yoink: Set OpenAI API Key"
       },
       {
-        "command": "repoLens.editTool",
-        "title": "RepoLens: Edit Tool"
+        "command": "yoink.editTool",
+        "title": "Yoink: Edit Tool"
       },
       {
-        "command": "repoLens.syncDataSourceFromTree",
+        "command": "yoink.syncDataSourceFromTree",
         "title": "Sync",
         "icon": "$(sync)"
       },
       {
-        "command": "repoLens.removeDataSourceFromTree",
+        "command": "yoink.removeDataSourceFromTree",
         "title": "Remove",
         "icon": "$(trash)"
       },
       {
-        "command": "repoLens.editToolFromTree",
+        "command": "yoink.editToolFromTree",
         "title": "Edit",
         "icon": "$(edit)"
       },
       {
-        "command": "repoLens.exportConfig",
-        "title": "RepoLens: Export Config to Workspace"
+        "command": "yoink.exportConfig",
+        "title": "Yoink: Export Config to Workspace"
       },
       {
-        "command": "repoLens.importConfig",
-        "title": "RepoLens: Import Config from Workspace"
+        "command": "yoink.importConfig",
+        "title": "Yoink: Import Config from Workspace"
       }
     ],
     "menus": {
       "view/item/context": [
         {
-          "command": "repoLens.syncDataSourceFromTree",
-          "when": "view == repoLens.dataSources && viewItem == dataSource",
+          "command": "yoink.syncDataSourceFromTree",
+          "when": "view == yoink.dataSources && viewItem == dataSource",
           "group": "inline"
         },
         {
-          "command": "repoLens.removeDataSourceFromTree",
-          "when": "view == repoLens.dataSources && viewItem == dataSource",
+          "command": "yoink.removeDataSourceFromTree",
+          "when": "view == yoink.dataSources && viewItem == dataSource",
           "group": "inline"
         },
         {
-          "command": "repoLens.editToolFromTree",
-          "when": "view == repoLens.tools && viewItem == tool",
+          "command": "yoink.editToolFromTree",
+          "when": "view == yoink.tools && viewItem == tool",
           "group": "inline"
         }
       ]
@@ -99,32 +99,32 @@
     "viewsContainers": {
       "activitybar": [
         {
-          "id": "repoLens",
-          "title": "RepoLens",
+          "id": "yoink",
+          "title": "Yoink",
           "icon": "$(database)"
         }
       ]
     },
     "views": {
-      "repoLens": [
+      "yoink": [
         {
-          "id": "repoLens.embedding",
+          "id": "yoink.embedding",
           "name": "Embedding"
         },
         {
-          "id": "repoLens.dataSources",
+          "id": "yoink.dataSources",
           "name": "Data Sources"
         },
         {
-          "id": "repoLens.tools",
+          "id": "yoink.tools",
           "name": "Tools"
         }
       ]
     },
     "configuration": {
-      "title": "RepoLens",
+      "title": "Yoink",
       "properties": {
-        "repoLens.embedding.provider": {
+        "yoink.embedding.provider": {
           "type": "string",
           "enum": [
             "openai"
@@ -132,29 +132,29 @@
           "default": "openai",
           "description": "Embedding provider to use for indexing."
         },
-        "repoLens.embedding.openai.model": {
+        "yoink.embedding.openai.model": {
           "type": "string",
           "default": "text-embedding-3-small",
           "description": "OpenAI embedding model to use."
         },
-        "repoLens.embedding.openai.baseUrl": {
+        "yoink.embedding.openai.baseUrl": {
           "type": "string",
           "default": "https://api.openai.com/v1",
           "description": "Base URL for OpenAI-compatible API (for proxies or compatible services)."
         },
-        "repoLens.search.topK": {
+        "yoink.search.topK": {
           "type": "number",
           "default": 10,
           "minimum": 1,
           "maximum": 50,
           "description": "Number of chunks to return per tool query."
         },
-        "repoLens.sync.onStartup": {
+        "yoink.sync.onStartup": {
           "type": "boolean",
           "default": true,
           "description": "Automatically sync data sources marked 'onStartup' when VS Code launches."
         },
-        "repoLens.log.level": {
+        "yoink.log.level": {
           "type": "string",
           "enum": [
             "debug",
@@ -169,13 +169,13 @@
     },
     "languageModelTools": [
       {
-        "name": "repolens-search",
-        "toolReferenceName": "repolens",
+        "name": "yoink-search",
+        "toolReferenceName": "yoink",
         "canBeReferencedInPrompt": true,
-        "tags": ["repolens", "search", "rag", "github", "codebase"],
-        "displayName": "RepoLens: Search Repositories",
+        "tags": ["yoink", "search", "rag", "github", "codebase"],
+        "displayName": "Yoink: Search Repositories",
         "userDescription": "Search your indexed GitHub repositories for relevant code, documentation, or knowledge.",
-        "modelDescription": "Search indexed GitHub repositories using vector similarity. Returns relevant code snippets and documentation. Use 'repository' to filter by a specific repo (owner/repo format), or 'tool' to use a configured tool scope. Call repolens-list first to discover available repositories and tools.",
+        "modelDescription": "Search indexed GitHub repositories using vector similarity. Returns relevant code snippets and documentation. Use 'repository' to filter by a specific repo (owner/repo format), or 'tool' to use a configured tool scope. Call yoink-list first to discover available repositories and tools.",
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -189,29 +189,30 @@
             },
             "tool": {
               "type": "string",
-              "description": "Optional: use a configured RepoLens tool name to search only its assigned repositories. Get available tool names from repolens-list."
+              "description": "Optional: use a configured Yoink tool name to search only its assigned repositories. Get available tool names from yoink-list."
             }
           },
           "required": ["query"]
         }
       },
       {
-        "name": "repolens-list",
-        "toolReferenceName": "repolens-list",
+        "name": "yoink-list",
+        "toolReferenceName": "yoink-list",
         "canBeReferencedInPrompt": true,
-        "tags": ["repolens", "list", "discover", "repositories"],
-        "displayName": "RepoLens: List Data Sources",
-        "userDescription": "List all indexed GitHub repositories and configured search tools in RepoLens.",
-        "modelDescription": "List all data sources (GitHub repositories) and tools currently indexed and available in RepoLens. Call this first to discover what repositories are available before searching. Returns repository names, branches, status, file/chunk counts, and any configured tool scopes.",
+        "tags": ["yoink", "list", "discover", "repositories"],
+        "displayName": "Yoink: List Data Sources",
+        "userDescription": "List all indexed GitHub repositories and configured search tools in Yoink.",
+        "modelDescription": "List all data sources (GitHub repositories) and tools currently indexed and available in Yoink. Call this first to discover what repositories are available before searching. Returns repository names, branches, status, file/chunk counts, and any configured tool scopes.",
         "inputSchema": {
           "type": "object",
           "properties": {}
-        },
-        {
-        "name": "repolens-get-file",
-        "toolReferenceName": "repolensGetFile",
-        "tags": ["repolens", "github", "file", "code"],
-        "displayName": "RepoLens: Get File",
+        }
+      },
+      {
+        "name": "yoink-get-file",
+        "toolReferenceName": "yoinkGetFile",
+        "tags": ["yoink", "github", "file", "code"],
+        "displayName": "Yoink: Get File",
         "userDescription": "Fetch the full content of a file from an indexed GitHub repository.",
         "modelDescription": "Fetch the full or partial content of a file from an indexed GitHub repository. Use this when search results reference a file and you need more context than the returned chunk provides. Provide startLine and endLine to fetch a specific section of a large file.",
         "inputSchema": {

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# dev-install.sh — build, install, and launch a fresh VS Code window with RepoLens active
+# dev-install.sh — build, install, and launch a fresh VS Code window with Yoink active
 
 set -euo pipefail
 
@@ -42,15 +42,15 @@ if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
 fi
 
 echo "==> Packaging VSIX..."
-npx vsce package --no-dependencies --out repolens-dev.vsix
+npx vsce package --no-dependencies --out yoink-dev.vsix
 
 echo "==> Installing extension..."
-"$CODE" --install-extension repolens-dev.vsix --force
+"$CODE" --install-extension yoink-dev.vsix --force
 
 echo "==> Opening new VS Code window..."
 "$CODE" --new-window .
 
 echo ""
 echo "Done. To view logs:"
-echo "  VS Code → View → Output → select 'RepoLens' from the dropdown"
-echo "  Or set repoLens.log.level to 'debug' in settings for verbose output"
+echo "  VS Code → View → Output → select 'Yoink' from the dropdown"
+echo "  Or set yoink.log.level to 'debug' in settings for verbose output"

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import {
-  RepoLensConfig,
+  YoinkConfig,
   DataSourceConfig,
   ToolConfig,
   createDefaultConfig,
@@ -11,9 +11,9 @@ import {
 const DEBOUNCE_MS = 300;
 
 export class ConfigManager implements vscode.Disposable {
-  private config: RepoLensConfig;
+  private config: YoinkConfig;
   private readonly configPath: string;
-  private readonly _onDidChange = new vscode.EventEmitter<RepoLensConfig>();
+  private readonly _onDidChange = new vscode.EventEmitter<YoinkConfig>();
   readonly onDidChange = this._onDidChange.event;
 
   private debounceTimer: ReturnType<typeof setTimeout> | undefined;
@@ -21,15 +21,15 @@ export class ConfigManager implements vscode.Disposable {
   private suppressNextFileEvent = false;
 
   constructor(globalStorageUri: vscode.Uri) {
-    this.configPath = path.join(globalStorageUri.fsPath, 'repolens.json');
+    this.configPath = path.join(globalStorageUri.fsPath, 'yoink.json');
     this.config = this.load();
     this.setupFileWatcher();
   }
 
-  private load(): RepoLensConfig {
+  private load(): YoinkConfig {
     try {
       const raw = fs.readFileSync(this.configPath, 'utf-8');
-      const config = JSON.parse(raw) as RepoLensConfig;
+      const config = JSON.parse(raw) as YoinkConfig;
       // Migration: data sources created before type awareness default to 'general'
       for (const ds of config.dataSources) {
         if (!ds.type) ds.type = 'general';
@@ -104,7 +104,7 @@ export class ConfigManager implements vscode.Disposable {
     this._onDidChange.fire(this.config);
   }
 
-  getConfig(): Readonly<RepoLensConfig> {
+  getConfig(): Readonly<YoinkConfig> {
     return this.config;
   }
 

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -25,7 +25,7 @@ export interface ToolConfig {
   dataSourceIds: string[];
 }
 
-export interface RepoLensConfig {
+export interface YoinkConfig {
   version: number;
   dataSources: DataSourceConfig[];
   tools: ToolConfig[];
@@ -52,7 +52,7 @@ export const DEFAULT_EXCLUDE_PATTERNS: string[] = [
   '**/*.eot',
 ];
 
-// --- Shareable config types (for .vscode/repolens.json) ---
+// --- Shareable config types (for .vscode/yoink.json) ---
 
 export interface ShareableDataSource {
   repoUrl: string;
@@ -79,7 +79,7 @@ export interface ShareableConfig {
   defaultExcludePatterns?: string[];
 }
 
-export function createDefaultConfig(): RepoLensConfig {
+export function createDefaultConfig(): YoinkConfig {
   return {
     version: 1,
     dataSources: [],

--- a/src/config/settingsSchema.ts
+++ b/src/config/settingsSchema.ts
@@ -1,17 +1,17 @@
-export interface RepoLensSettings {
-  'repoLens.embedding.provider': 'openai';
-  'repoLens.embedding.openai.model': string;
-  'repoLens.embedding.openai.baseUrl': string;
-  'repoLens.search.topK': number;
-  'repoLens.sync.onStartup': boolean;
-  'repoLens.log.level': 'debug' | 'info' | 'warn' | 'error';
+export interface YoinkSettings {
+  'yoink.embedding.provider': 'openai';
+  'yoink.embedding.openai.model': string;
+  'yoink.embedding.openai.baseUrl': string;
+  'yoink.search.topK': number;
+  'yoink.sync.onStartup': boolean;
+  'yoink.log.level': 'debug' | 'info' | 'warn' | 'error';
 }
 
 export const SETTING_KEYS = {
-  EMBEDDING_PROVIDER: 'repoLens.embedding.provider',
-  OPENAI_MODEL: 'repoLens.embedding.openai.model',
-  OPENAI_BASE_URL: 'repoLens.embedding.openai.baseUrl',
-  SEARCH_TOP_K: 'repoLens.search.topK',
-  SYNC_ON_STARTUP: 'repoLens.sync.onStartup',
-  LOG_LEVEL: 'repoLens.log.level',
+  EMBEDDING_PROVIDER: 'yoink.embedding.provider',
+  OPENAI_MODEL: 'yoink.embedding.openai.model',
+  OPENAI_BASE_URL: 'yoink.embedding.openai.baseUrl',
+  SEARCH_TOP_K: 'yoink.search.topK',
+  SYNC_ON_STARTUP: 'yoink.sync.onStartup',
+  LOG_LEVEL: 'yoink.log.level',
 } as const;

--- a/src/config/workspaceConfig.ts
+++ b/src/config/workspaceConfig.ts
@@ -12,7 +12,7 @@ import {
 import { DataSourceManager } from '../sources/dataSourceManager';
 import { Logger } from '../util/logger';
 
-const WORKSPACE_CONFIG_FILENAME = 'repolens.json';
+const WORKSPACE_CONFIG_FILENAME = 'yoink.json';
 const WORKSPACE_CONFIG_DIR = '.vscode';
 
 export interface ImportResult {
@@ -31,7 +31,7 @@ export class WorkspaceConfigManager {
   ) {}
 
   /**
-   * Detect .vscode/repolens.json in the primary workspace folder
+   * Detect .vscode/yoink.json in the primary workspace folder
    * and prompt the user to import it.
    */
   async detectAndPrompt(): Promise<void> {
@@ -46,7 +46,7 @@ export class WorkspaceConfigManager {
     if (shareable.dataSources.length === 0 && shareable.tools.length === 0) return;
 
     const action = await vscode.window.showInformationMessage(
-      'RepoLens config found in this workspace. Import tools and data sources?',
+      'Yoink config found in this workspace. Import tools and data sources?',
       'Import',
       'Not Now',
     );
@@ -58,13 +58,13 @@ export class WorkspaceConfigManager {
   }
 
   /**
-   * Export current config to .vscode/repolens.json in the primary workspace folder.
+   * Export current config to .vscode/yoink.json in the primary workspace folder.
    */
   async exportConfig(): Promise<void> {
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     if (!workspaceFolder) {
       vscode.window.showErrorMessage(
-        'Open a workspace folder first to export RepoLens config.',
+        'Open a workspace folder first to export Yoink config.',
       );
       return;
     }
@@ -74,7 +74,7 @@ export class WorkspaceConfigManager {
 
     if (fs.existsSync(targetPath)) {
       const overwrite = await vscode.window.showWarningMessage(
-        'Overwrite existing .vscode/repolens.json?',
+        'Overwrite existing .vscode/yoink.json?',
         { modal: true },
         'Overwrite',
       );
@@ -89,26 +89,26 @@ export class WorkspaceConfigManager {
     fs.writeFileSync(targetPath, JSON.stringify(shareable, null, 2));
 
     vscode.window.showInformationMessage(
-      `Exported ${shareable.dataSources.length} data sources and ${shareable.tools.length} tools to .vscode/repolens.json`,
+      `Exported ${shareable.dataSources.length} data sources and ${shareable.tools.length} tools to .vscode/yoink.json`,
     );
     this.logger.info(`Exported config to ${targetPath}`);
   }
 
   /**
-   * Import from .vscode/repolens.json in the primary workspace folder (manual command).
+   * Import from .vscode/yoink.json in the primary workspace folder (manual command).
    */
   async importFromWorkspace(): Promise<void> {
     const configPath = this.getWorkspaceConfigPath();
     if (!configPath) {
       vscode.window.showErrorMessage(
-        'Open a workspace folder first to import RepoLens config.',
+        'Open a workspace folder first to import Yoink config.',
       );
       return;
     }
 
     if (!fs.existsSync(configPath)) {
       vscode.window.showInformationMessage(
-        'No .vscode/repolens.json found in this workspace.',
+        'No .vscode/yoink.json found in this workspace.',
       );
       return;
     }
@@ -116,7 +116,7 @@ export class WorkspaceConfigManager {
     const shareable = this.readShareableConfig(configPath);
     if (!shareable) {
       vscode.window.showErrorMessage(
-        'Failed to parse .vscode/repolens.json. Check the file format.',
+        'Failed to parse .vscode/yoink.json. Check the file format.',
       );
       return;
     }
@@ -221,7 +221,7 @@ export class WorkspaceConfigManager {
     }));
 
     const shareable: ShareableConfig = {
-      $schema: 'https://repolens.dev/schema/shareable-config.json',
+      $schema: 'https://yoink.dev/schema/shareable-config.json',
       version: 1,
       dataSources,
       tools,
@@ -299,12 +299,12 @@ export class WorkspaceConfigManager {
 
     if (parts.length === 0 && skipped > 0) {
       vscode.window.showInformationMessage(
-        `RepoLens: All ${skipped} items already exist. Nothing to import.`,
+        `Yoink: All ${skipped} items already exist. Nothing to import.`,
       );
       return;
     }
 
-    let message = `RepoLens: Imported ${parts.join(' and ')}`;
+    let message = `Yoink: Imported ${parts.join(' and ')}`;
     if (skipped > 0) {
       message += ` (${skipped} already existed)`;
     }
@@ -312,7 +312,7 @@ export class WorkspaceConfigManager {
 
     if (result.warnings.length > 0) {
       vscode.window.showWarningMessage(
-        `${message} ${result.warnings.length} warning(s) — check the RepoLens output log.`,
+        `${message} ${result.warnings.length} warning(s) — check the Yoink output log.`,
       );
     } else {
       vscode.window.showInformationMessage(message);

--- a/src/embedding/registry.ts
+++ b/src/embedding/registry.ts
@@ -24,7 +24,7 @@ export class EmbeddingProviderRegistry {
     const apiKey = await this.resolveApiKey();
     if (!apiKey) {
       throw new Error(
-        'OpenAI API key not configured. Run "RepoLens: Set OpenAI API Key" or set the OPENAI_API_KEY environment variable.',
+        'OpenAI API key not configured. Run "Yoink: Set OpenAI API Key" or set the OPENAI_API_KEY environment variable.',
       );
     }
 
@@ -41,7 +41,7 @@ export class EmbeddingProviderRegistry {
 
   private async resolveApiKey(): Promise<string | undefined> {
     // 1. SecretStorage (primary)
-    const stored = await this.secretStorage.get('repoLens.openai.apiKey');
+    const stored = await this.secretStorage.get('yoink.openai.apiKey');
     if (stored) return stored;
 
     // 2. Environment variable (fallback)
@@ -52,10 +52,10 @@ export class EmbeddingProviderRegistry {
   }
 
   async setApiKey(key: string): Promise<void> {
-    await this.secretStorage.store('repoLens.openai.apiKey', key);
+    await this.secretStorage.store('yoink.openai.apiKey', key);
   }
 
   async clearApiKey(): Promise<void> {
-    await this.secretStorage.delete('repoLens.openai.apiKey');
+    await this.secretStorage.delete('yoink.openai.apiKey');
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ import { Logger } from './util/logger';
 
 export function activate(context: vscode.ExtensionContext): void {
   const logger = new Logger();
-  logger.info('RepoLens activating');
+  logger.info('Yoink activating');
 
   // Config
   const configManager = new ConfigManager(context.globalStorageUri);
@@ -67,7 +67,7 @@ export function activate(context: vscode.ExtensionContext): void {
   pipeline.onIndexingError((dataSourceId, message) => {
     const ds = configManager.getDataSource(dataSourceId);
     const label = ds ? `${ds.owner}/${ds.repo}` : dataSourceId;
-    vscode.window.showErrorMessage(`RepoLens: Indexing failed for ${label}: ${message}`);
+    vscode.window.showErrorMessage(`Yoink: Indexing failed for ${label}: ${message}`);
   });
 
   // Data source management
@@ -93,9 +93,9 @@ export function activate(context: vscode.ExtensionContext): void {
   const dataSourceTreeProvider = new DataSourceTreeProvider(configManager, chunkStore);
   const toolTreeProvider = new ToolTreeProvider(configManager);
   const embeddingTreeProvider = new EmbeddingTreeProvider(providerRegistry, context.secrets);
-  vscode.window.registerTreeDataProvider('repoLens.dataSources', dataSourceTreeProvider);
-  vscode.window.registerTreeDataProvider('repoLens.tools', toolTreeProvider);
-  vscode.window.registerTreeDataProvider('repoLens.embedding', embeddingTreeProvider);
+  vscode.window.registerTreeDataProvider('yoink.dataSources', dataSourceTreeProvider);
+  vscode.window.registerTreeDataProvider('yoink.tools', toolTreeProvider);
+  vscode.window.registerTreeDataProvider('yoink.embedding', embeddingTreeProvider);
 
   // Workspace config (shareable)
   const workspaceConfigManager = new WorkspaceConfigManager(
@@ -132,7 +132,7 @@ export function activate(context: vscode.ExtensionContext): void {
   // Detect workspace config and prompt import
   workspaceConfigManager.detectAndPrompt();
 
-  logger.info('RepoLens activated');
+  logger.info('Yoink activated');
 }
 
 export function deactivate(): void {

--- a/src/sources/dataSourceManager.ts
+++ b/src/sources/dataSourceManager.ts
@@ -71,11 +71,11 @@ export class DataSourceManager implements vscode.Disposable {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const action = await vscode.window.showErrorMessage(
-        `RepoLens: ${message}`,
+        `Yoink: ${message}`,
         'Set API Key',
       );
       if (action === 'Set API Key') {
-        await vscode.commands.executeCommand('repoLens.setApiKey');
+        await vscode.commands.executeCommand('yoink.setApiKey');
       }
       throw err;
     }

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -20,7 +20,7 @@ export function openDatabase(options: OpenDatabaseOptions = {}): Database.Databa
     if (!fs.existsSync(options.storagePath)) {
       fs.mkdirSync(options.storagePath, { recursive: true });
     }
-    const dbPath = path.join(options.storagePath, 'repolens.db');
+    const dbPath = path.join(options.storagePath, 'yoink.db');
     db = new Database(dbPath);
   } else {
     db = new Database(':memory:');

--- a/src/tools/getFileTool.ts
+++ b/src/tools/getFileTool.ts
@@ -3,8 +3,8 @@
 // tool description used for Copilot discovery.
 
 export const GET_FILE_TOOL = {
-  name: 'repolens-get-file',
-  displayName: 'RepoLens: Get File',
+  name: 'yoink-get-file',
+  displayName: 'Yoink: Get File',
   description:
     'Fetch the full content of a file from an indexed GitHub repository. ' +
     'Use this when search results reference a file and you need more context ' +

--- a/src/tools/globalSearchTool.ts
+++ b/src/tools/globalSearchTool.ts
@@ -3,8 +3,8 @@
 // tool description used for Copilot discovery.
 
 export const GLOBAL_SEARCH_TOOL = {
-  name: 'repolens-search',
-  displayName: 'RepoLens Search',
+  name: 'yoink-search',
+  displayName: 'Yoink Search',
   description:
     'Search across all configured repository knowledge bases. ' +
     'Use this to find code, documentation, patterns, or examples ' +
@@ -19,7 +19,7 @@ export const GLOBAL_SEARCH_TOOL = {
       tool: {
         type: 'string' as const,
         description:
-          'Optional: use a configured RepoLens tool name to search only its assigned repositories.',
+          'Optional: use a configured Yoink tool name to search only its assigned repositories.',
       },
     },
     required: ['query'],
@@ -27,8 +27,8 @@ export const GLOBAL_SEARCH_TOOL = {
 };
 
 export const LIST_TOOL = {
-  name: 'repolens-list',
-  displayName: 'RepoLens List',
+  name: 'yoink-list',
+  displayName: 'Yoink List',
   description:
-    'List all indexed data sources and configured tools in RepoLens.',
+    'List all indexed data sources and configured tools in Yoink.',
 };

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -90,7 +90,7 @@ export class ToolHandler {
     if (readySources.length === 0) {
       return new vscode.LanguageModelToolResult([
         new vscode.LanguageModelTextPart(
-          'No repositories are indexed yet. Add a repository via the RepoLens sidebar and wait for indexing to complete.',
+          'No repositories are indexed yet. Add a repository via the Yoink sidebar and wait for indexing to complete.',
         ),
       ]);
     }

--- a/src/tools/toolManager.ts
+++ b/src/tools/toolManager.ts
@@ -21,7 +21,7 @@ export class ToolManager implements vscode.Disposable {
   private registerGlobalSearchTool(): void {
     if (this.registeredTools.has('__global__')) return;
 
-    const disposable = vscode.lm.registerTool('repolens-search', {
+    const disposable = vscode.lm.registerTool('yoink-search', {
       invoke: async (options, token) => {
         return this.toolHandler.handleGlobalSearch(
           options as vscode.LanguageModelToolInvocationOptions<{ query: string; repository?: string; tool?: string }>,
@@ -74,7 +74,7 @@ export class ToolManager implements vscode.Disposable {
       }
     }
 
-    const disposable = vscode.lm.registerTool('repolens-list', {
+    const disposable = vscode.lm.registerTool('yoink-list', {
       invoke: async (_options, token) => {
         return this.toolHandler.handleList(token);
       },

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -15,12 +15,12 @@ export function registerCommands(
   workspaceConfigManager: WorkspaceConfigManager,
 ): void {
   context.subscriptions.push(
-    vscode.commands.registerCommand('repoLens.addRepository', async () => {
+    vscode.commands.registerCommand('yoink.addRepository', async () => {
       const wizard = wizardFactory();
       await wizard.run();
     }),
 
-    vscode.commands.registerCommand('repoLens.removeRepository', async () => {
+    vscode.commands.registerCommand('yoink.removeRepository', async () => {
       const dataSources = configManager.getDataSources();
       if (dataSources.length === 0) {
         vscode.window.showInformationMessage('No data sources configured.');
@@ -40,7 +40,7 @@ export function registerCommands(
       }
     }),
 
-    vscode.commands.registerCommand('repoLens.syncDataSource', async () => {
+    vscode.commands.registerCommand('yoink.syncDataSource', async () => {
       const dataSources = configManager.getDataSources();
       if (dataSources.length === 0) {
         vscode.window.showInformationMessage('No data sources configured.');
@@ -60,12 +60,12 @@ export function registerCommands(
       }
     }),
 
-    vscode.commands.registerCommand('repoLens.syncAllDataSources', async () => {
+    vscode.commands.registerCommand('yoink.syncAllDataSources', async () => {
       await dataSourceManager.syncAll();
       vscode.window.showInformationMessage('Sync queued for all data sources.');
     }),
 
-    vscode.commands.registerCommand('repoLens.setApiKey', async () => {
+    vscode.commands.registerCommand('yoink.setApiKey', async () => {
       const key = await vscode.window.showInputBox({
         prompt: 'Enter your OpenAI API key',
         password: true,
@@ -79,14 +79,14 @@ export function registerCommands(
     }),
 
     // Tree-item context menu commands
-    vscode.commands.registerCommand('repoLens.syncDataSourceFromTree', async (item: DataSourceTreeItem) => {
+    vscode.commands.registerCommand('yoink.syncDataSourceFromTree', async (item: DataSourceTreeItem) => {
       await dataSourceManager.sync(item.dataSource.id);
       vscode.window.showInformationMessage(
         `Sync queued for ${item.dataSource.owner}/${item.dataSource.repo}.`,
       );
     }),
 
-    vscode.commands.registerCommand('repoLens.removeDataSourceFromTree', async (item: DataSourceTreeItem) => {
+    vscode.commands.registerCommand('yoink.removeDataSourceFromTree', async (item: DataSourceTreeItem) => {
       const confirm = await vscode.window.showWarningMessage(
         `Remove ${item.dataSource.owner}/${item.dataSource.repo}? This will delete all indexed data.`,
         { modal: true },
@@ -100,7 +100,7 @@ export function registerCommands(
       }
     }),
 
-    vscode.commands.registerCommand('repoLens.editToolFromTree', async (item: ToolTreeItem) => {
+    vscode.commands.registerCommand('yoink.editToolFromTree', async (item: ToolTreeItem) => {
       const newDescription = await vscode.window.showInputBox({
         prompt: 'Tool description',
         value: item.tool.description,
@@ -112,7 +112,7 @@ export function registerCommands(
       }
     }),
 
-    vscode.commands.registerCommand('repoLens.editTool', async () => {
+    vscode.commands.registerCommand('yoink.editTool', async () => {
       const tools = configManager.getTools();
       if (tools.length === 0) {
         vscode.window.showInformationMessage('No tools configured.');
@@ -138,11 +138,11 @@ export function registerCommands(
       }
     }),
 
-    vscode.commands.registerCommand('repoLens.exportConfig', async () => {
+    vscode.commands.registerCommand('yoink.exportConfig', async () => {
       await workspaceConfigManager.exportConfig();
     }),
 
-    vscode.commands.registerCommand('repoLens.importConfig', async () => {
+    vscode.commands.registerCommand('yoink.importConfig', async () => {
       await workspaceConfigManager.importFromWorkspace();
     }),
   );

--- a/src/ui/sidebar/sidebarTreeItems.ts
+++ b/src/ui/sidebar/sidebarTreeItems.ts
@@ -106,7 +106,7 @@ export class EmbeddingTreeItem extends vscode.TreeItem {
       this.iconPath = new vscode.ThemeIcon('warning', new vscode.ThemeColor('problemsWarningIcon.foreground'));
       this.tooltip = `Embedding model: ${model}\nAPI key: not configured\nClick to set your OpenAI API key`;
       this.command = {
-        command: 'repoLens.setApiKey',
+        command: 'yoink.setApiKey',
         title: 'Set API Key',
       };
     }

--- a/src/ui/wizard/addRepoWizard.ts
+++ b/src/ui/wizard/addRepoWizard.ts
@@ -21,7 +21,7 @@ export class AddRepoWizard {
     // Step 0: Ensure API key is configured
     if (!(await this.embeddingRegistry.hasApiKey())) {
       const apiKey = await vscode.window.showInputBox({
-        title: 'RepoLens: OpenAI API Key Required',
+        title: 'Yoink: OpenAI API Key Required',
         prompt: 'Enter your OpenAI API key to enable embeddings',
         placeHolder: 'sk-...',
         password: true,

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -14,7 +14,7 @@ export class Logger implements vscode.Disposable {
   private readonly channel: vscode.OutputChannel;
 
   constructor() {
-    this.channel = vscode.window.createOutputChannel('RepoLens');
+    this.channel = vscode.window.createOutputChannel('Yoink');
   }
 
   debug(message: string): void {

--- a/test/unit/config/configManager.test.ts
+++ b/test/unit/config/configManager.test.ts
@@ -51,7 +51,7 @@ describe('ConfigManager', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repolens-test-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yoink-test-'));
     changeListeners.length = 0;
     fileWatcherCallbacks.change.length = 0;
     fileWatcherCallbacks.create.length = 0;
@@ -66,11 +66,11 @@ describe('ConfigManager', () => {
   }
 
   function writeConfig(config: any) {
-    fs.writeFileSync(path.join(tmpDir, 'repolens.json'), JSON.stringify(config, null, 2));
+    fs.writeFileSync(path.join(tmpDir, 'yoink.json'), JSON.stringify(config, null, 2));
   }
 
   function readConfig() {
-    return JSON.parse(fs.readFileSync(path.join(tmpDir, 'repolens.json'), 'utf-8'));
+    return JSON.parse(fs.readFileSync(path.join(tmpDir, 'yoink.json'), 'utf-8'));
   }
 
   it('returns default config when no file exists', () => {
@@ -106,7 +106,7 @@ describe('ConfigManager', () => {
   });
 
   it('handles corrupt JSON by backing up and resetting to defaults', () => {
-    const configPath = path.join(tmpDir, 'repolens.json');
+    const configPath = path.join(tmpDir, 'yoink.json');
     fs.writeFileSync(configPath, '{corrupt json!!!');
 
     const manager = new ConfigManager(makeUri());
@@ -218,7 +218,7 @@ describe('ConfigManager', () => {
     }
 
     // File should not exist yet (debounced)
-    const configPath = path.join(tmpDir, 'repolens.json');
+    const configPath = path.join(tmpDir, 'yoink.json');
     const existsBeforeFlush = fs.existsSync(configPath);
 
     // Flush to write

--- a/test/unit/config/workspaceConfig.test.ts
+++ b/test/unit/config/workspaceConfig.test.ts
@@ -65,7 +65,7 @@ function makeDs(owner: string, repo: string, branch = 'main', id = 'ds-1'): Data
   };
 }
 
-const WORKSPACE_CONFIG_PATH = path.join('/workspace', '.vscode', 'repolens.json');
+const WORKSPACE_CONFIG_PATH = path.join('/workspace', '.vscode', 'yoink.json');
 
 describe('WorkspaceConfigManager', () => {
   beforeEach(() => {
@@ -318,7 +318,7 @@ describe('WorkspaceConfigManager', () => {
   });
 
   describe('exportConfig', () => {
-    it('writes shareable config to .vscode/repolens.json', async () => {
+    it('writes shareable config to .vscode/yoink.json', async () => {
       const ds = makeDs('acme', 'widgets');
       const configManager = makeConfigManager({ dataSources: [ds] });
       const mgr = new WorkspaceConfigManager(configManager, makeDataSourceManager(), makeLogger());
@@ -349,7 +349,7 @@ describe('WorkspaceConfigManager', () => {
       await mgr.exportConfig();
 
       expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
-        'Overwrite existing .vscode/repolens.json?',
+        'Overwrite existing .vscode/yoink.json?',
         { modal: true },
         'Overwrite',
       );
@@ -378,7 +378,7 @@ describe('WorkspaceConfigManager', () => {
       await mgr.exportConfig();
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'Open a workspace folder first to export RepoLens config.',
+        'Open a workspace folder first to export Yoink config.',
       );
 
       // Restore
@@ -404,7 +404,7 @@ describe('WorkspaceConfigManager', () => {
       await mgr.detectAndPrompt();
 
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-        'RepoLens config found in this workspace. Import tools and data sources?',
+        'Yoink config found in this workspace. Import tools and data sources?',
         'Import',
         'Not Now',
       );

--- a/test/unit/storage/database.test.ts
+++ b/test/unit/storage/database.test.ts
@@ -9,7 +9,7 @@ describe('openDatabase', () => {
   const tempDirs: string[] = [];
 
   function makeTempDir(): string {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repolens-test-'));
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'yoink-test-'));
     tempDirs.push(dir);
     return dir;
   }
@@ -70,7 +70,7 @@ describe('openDatabase', () => {
   it('creates a file-backed database', () => {
     const dir = makeTempDir();
     const db = openDatabase({ storagePath: dir });
-    const dbFile = path.join(dir, 'repolens.db');
+    const dbFile = path.join(dir, 'yoink.db');
     expect(fs.existsSync(dbFile)).toBe(true);
     db.close();
   });

--- a/test/unit/tools/toolManager.test.ts
+++ b/test/unit/tools/toolManager.test.ts
@@ -45,8 +45,8 @@ describe('ToolManager', () => {
     const manager = new ToolManager(toolHandler, logger);
     manager.registerAll();
 
-    expect(registeredTools.has('repolens-search')).toBe(true);
-    expect(registeredTools.has('repolens-list')).toBe(true);
+    expect(registeredTools.has('yoink-search')).toBe(true);
+    expect(registeredTools.has('yoink-list')).toBe(true);
     manager.dispose();
   });
 
@@ -56,7 +56,7 @@ describe('ToolManager', () => {
     manager.registerAll();
 
     manager.dispose();
-    const globalDisposals = disposedTools.filter((n) => n === 'repolens-search');
+    const globalDisposals = disposedTools.filter((n) => n === 'yoink-search');
     expect(globalDisposals.length).toBe(1);
   });
 
@@ -66,7 +66,7 @@ describe('ToolManager', () => {
     manager.registerAll();
 
     manager.dispose();
-    const listDisposals = disposedTools.filter((n) => n === 'repolens-list');
+    const listDisposals = disposedTools.filter((n) => n === 'yoink-list');
     expect(listDisposals.length).toBe(1);
   });
 
@@ -74,7 +74,7 @@ describe('ToolManager', () => {
     const manager = new ToolManager(toolHandler, logger);
     manager.registerAll();
 
-    const handler = registeredTools.get('repolens-search');
+    const handler = registeredTools.get('yoink-search');
     const mockOptions = { input: { query: 'test' } };
     const mockToken = { isCancellationRequested: false };
 
@@ -88,7 +88,7 @@ describe('ToolManager', () => {
     const manager = new ToolManager(toolHandler, logger);
     manager.registerAll();
 
-    const handler = registeredTools.get('repolens-list');
+    const handler = registeredTools.get('yoink-list');
     const mockOptions = { input: {} };
     const mockToken = { isCancellationRequested: false };
 
@@ -104,7 +104,7 @@ describe('ToolManager', () => {
 
     manager.dispose();
 
-    expect(disposedTools).toContain('repolens-search');
-    expect(disposedTools).toContain('repolens-list');
+    expect(disposedTools).toContain('yoink-search');
+    expect(disposedTools).toContain('yoink-list');
   });
 });

--- a/test/unit/ui/commands.test.ts
+++ b/test/unit/ui/commands.test.ts
@@ -66,19 +66,19 @@ describe('registerCommands', () => {
   });
 
   it('registers all expected commands', () => {
-    expect(commands.has('repoLens.addRepository')).toBe(true);
-    expect(commands.has('repoLens.removeRepository')).toBe(true);
-    expect(commands.has('repoLens.syncDataSource')).toBe(true);
-    expect(commands.has('repoLens.syncAllDataSources')).toBe(true);
-    expect(commands.has('repoLens.setApiKey')).toBe(true);
-    expect(commands.has('repoLens.editTool')).toBe(true);
+    expect(commands.has('yoink.addRepository')).toBe(true);
+    expect(commands.has('yoink.removeRepository')).toBe(true);
+    expect(commands.has('yoink.syncDataSource')).toBe(true);
+    expect(commands.has('yoink.syncAllDataSources')).toBe(true);
+    expect(commands.has('yoink.setApiKey')).toBe(true);
+    expect(commands.has('yoink.editTool')).toBe(true);
   });
 
   it('addRepository runs the wizard', async () => {
     const mockWizard = { run: vi.fn() };
     wizardFactory.mockReturnValue(mockWizard);
 
-    await commands.get('repoLens.addRepository')!();
+    await commands.get('yoink.addRepository')!();
 
     expect(wizardFactory).toHaveBeenCalled();
     expect(mockWizard.run).toHaveBeenCalled();
@@ -89,7 +89,7 @@ describe('registerCommands', () => {
       label: 'acme/widgets', id: 'ds-1',
     });
 
-    await commands.get('repoLens.removeRepository')!();
+    await commands.get('yoink.removeRepository')!();
 
     expect(dataSourceManager.remove).toHaveBeenCalledWith('ds-1');
   });
@@ -97,7 +97,7 @@ describe('registerCommands', () => {
   it('removeRepository does nothing when no selection', async () => {
     (vscode.window.showQuickPick as any).mockResolvedValue(undefined);
 
-    await commands.get('repoLens.removeRepository')!();
+    await commands.get('yoink.removeRepository')!();
 
     expect(dataSourceManager.remove).not.toHaveBeenCalled();
   });
@@ -105,7 +105,7 @@ describe('registerCommands', () => {
   it('removeRepository shows message when no data sources', async () => {
     configManager.getDataSources.mockReturnValue([]);
 
-    await commands.get('repoLens.removeRepository')!();
+    await commands.get('yoink.removeRepository')!();
 
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
       'No data sources configured.',
@@ -117,13 +117,13 @@ describe('registerCommands', () => {
       label: 'acme/widgets', id: 'ds-1',
     });
 
-    await commands.get('repoLens.syncDataSource')!();
+    await commands.get('yoink.syncDataSource')!();
 
     expect(dataSourceManager.sync).toHaveBeenCalledWith('ds-1');
   });
 
   it('syncAllDataSources syncs all', async () => {
-    await commands.get('repoLens.syncAllDataSources')!();
+    await commands.get('yoink.syncAllDataSources')!();
 
     expect(dataSourceManager.syncAll).toHaveBeenCalled();
   });
@@ -131,7 +131,7 @@ describe('registerCommands', () => {
   it('setApiKey saves the key', async () => {
     (vscode.window.showInputBox as any).mockResolvedValue('sk-test-key-123');
 
-    await commands.get('repoLens.setApiKey')!();
+    await commands.get('yoink.setApiKey')!();
 
     expect(providerRegistry.setApiKey).toHaveBeenCalledWith('sk-test-key-123');
   });
@@ -139,7 +139,7 @@ describe('registerCommands', () => {
   it('setApiKey does nothing when cancelled', async () => {
     (vscode.window.showInputBox as any).mockResolvedValue(undefined);
 
-    await commands.get('repoLens.setApiKey')!();
+    await commands.get('yoink.setApiKey')!();
 
     expect(providerRegistry.setApiKey).not.toHaveBeenCalled();
   });
@@ -150,7 +150,7 @@ describe('registerCommands', () => {
     });
     (vscode.window.showInputBox as any).mockResolvedValue('Updated description');
 
-    await commands.get('repoLens.editTool')!();
+    await commands.get('yoink.editTool')!();
 
     expect(configManager.updateTool).toHaveBeenCalledWith('t-1', {
       description: 'Updated description',
@@ -160,7 +160,7 @@ describe('registerCommands', () => {
   it('editTool shows message when no tools configured', async () => {
     configManager.getTools.mockReturnValue([]);
 
-    await commands.get('repoLens.editTool')!();
+    await commands.get('yoink.editTool')!();
 
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
       'No tools configured.',
@@ -168,17 +168,17 @@ describe('registerCommands', () => {
   });
 
   it('registers export and import commands', () => {
-    expect(commands.has('repoLens.exportConfig')).toBe(true);
-    expect(commands.has('repoLens.importConfig')).toBe(true);
+    expect(commands.has('yoink.exportConfig')).toBe(true);
+    expect(commands.has('yoink.importConfig')).toBe(true);
   });
 
   it('exportConfig delegates to workspaceConfigManager', async () => {
-    await commands.get('repoLens.exportConfig')!();
+    await commands.get('yoink.exportConfig')!();
     expect(workspaceConfigManager.exportConfig).toHaveBeenCalled();
   });
 
   it('importConfig delegates to workspaceConfigManager', async () => {
-    await commands.get('repoLens.importConfig')!();
+    await commands.get('yoink.importConfig')!();
     expect(workspaceConfigManager.importFromWorkspace).toHaveBeenCalled();
   });
 });

--- a/yoink.json.schema.json
+++ b/yoink.json.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "RepoLens Configuration",
+  "title": "Yoink Configuration",
   "type": "object",
   "required": ["version", "dataSources", "tools", "defaultExcludePatterns"],
   "properties": {


### PR DESCRIPTION
Renames all occurrences of RepoLens/repolens/repoLens/repo-lens to
Yoink/yoink throughout source, tests, docs, scripts, and config:
- package.json: name, displayName, publisher, command IDs, view IDs,
  config keys, languageModelTool names and tags
- Renames repolens.json.schema.json → yoink.json.schema.json
- Config files: repolens.json → yoink.json, repolens.db → yoink.db
- Type names: RepoLensConfig → YoinkConfig, RepoLensSettings → YoinkSettings
- Output channel, tool registration names, command strings, UI prompts
- Also fixes pre-existing invalid JSON in package.json (missing closing
  brace on repolens-list languageModelTools entry)

https://claude.ai/code/session_015GVEFaCEWTMPTyYUNDJUaN