### PR TITLE
Add Azure OpenAI and local embedding provider support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
         "title": "Yoink: Set OpenAI API Key"
       },
       {
+        "command": "yoink.setAzureApiKey",
+        "title": "Yoink: Set Azure OpenAI API Key"
+      },
+      {
         "command": "yoink.editTool",
         "title": "Yoink: Edit Tool"
       },
@@ -127,7 +131,14 @@
         "yoink.embedding.provider": {
           "type": "string",
           "enum": [
-            "openai"
+            "openai",
+            "azure-openai",
+            "local"
+          ],
+          "enumDescriptions": [
+            "OpenAI embedding API (requires API key)",
+            "Azure OpenAI deployment (requires API key, endpoint, and deployment name)",
+            "Local OpenAI-compatible server such as Ollama (no API key required)"
           ],
           "default": "openai",
           "description": "Embedding provider to use for indexing."
@@ -141,6 +152,41 @@
           "type": "string",
           "default": "https://api.openai.com/v1",
           "description": "Base URL for OpenAI-compatible API (for proxies or compatible services)."
+        },
+        "yoink.embedding.azure.endpoint": {
+          "type": "string",
+          "default": "",
+          "description": "Azure OpenAI resource endpoint URL, e.g. https://myresource.openai.azure.com"
+        },
+        "yoink.embedding.azure.deploymentName": {
+          "type": "string",
+          "default": "",
+          "description": "Azure OpenAI deployment name for the embedding model."
+        },
+        "yoink.embedding.azure.apiVersion": {
+          "type": "string",
+          "default": "2024-02-01",
+          "description": "Azure OpenAI API version."
+        },
+        "yoink.embedding.azure.dimensions": {
+          "type": "number",
+          "default": 1536,
+          "description": "Embedding vector dimensions for the Azure OpenAI deployment. Must match the deployed model (e.g. 1536 for text-embedding-3-small, 3072 for text-embedding-3-large)."
+        },
+        "yoink.embedding.local.baseUrl": {
+          "type": "string",
+          "default": "http://localhost:11434/v1",
+          "description": "Base URL of the local OpenAI-compatible embedding server (e.g. Ollama)."
+        },
+        "yoink.embedding.local.model": {
+          "type": "string",
+          "default": "",
+          "description": "Model name to request from the local embedding server, e.g. nomic-embed-text."
+        },
+        "yoink.embedding.local.dimensions": {
+          "type": "number",
+          "default": 768,
+          "description": "Embedding vector dimensions produced by the local model. Must match the actual model output (e.g. 768 for nomic-embed-text)."
         },
         "yoink.search.topK": {
           "type": "number",

--- a/src/config/settingsSchema.ts
+++ b/src/config/settingsSchema.ts
@@ -1,7 +1,14 @@
 export interface YoinkSettings {
-  'yoink.embedding.provider': 'openai';
+  'yoink.embedding.provider': 'openai' | 'azure-openai' | 'local';
   'yoink.embedding.openai.model': string;
   'yoink.embedding.openai.baseUrl': string;
+  'yoink.embedding.azure.endpoint': string;
+  'yoink.embedding.azure.deploymentName': string;
+  'yoink.embedding.azure.apiVersion': string;
+  'yoink.embedding.azure.dimensions': number;
+  'yoink.embedding.local.baseUrl': string;
+  'yoink.embedding.local.model': string;
+  'yoink.embedding.local.dimensions': number;
   'yoink.search.topK': number;
   'yoink.sync.onStartup': boolean;
   'yoink.log.level': 'debug' | 'info' | 'warn' | 'error';
@@ -11,6 +18,13 @@ export const SETTING_KEYS = {
   EMBEDDING_PROVIDER: 'yoink.embedding.provider',
   OPENAI_MODEL: 'yoink.embedding.openai.model',
   OPENAI_BASE_URL: 'yoink.embedding.openai.baseUrl',
+  AZURE_ENDPOINT: 'yoink.embedding.azure.endpoint',
+  AZURE_DEPLOYMENT_NAME: 'yoink.embedding.azure.deploymentName',
+  AZURE_API_VERSION: 'yoink.embedding.azure.apiVersion',
+  AZURE_DIMENSIONS: 'yoink.embedding.azure.dimensions',
+  LOCAL_BASE_URL: 'yoink.embedding.local.baseUrl',
+  LOCAL_MODEL: 'yoink.embedding.local.model',
+  LOCAL_DIMENSIONS: 'yoink.embedding.local.dimensions',
   SEARCH_TOP_K: 'yoink.search.topK',
   SYNC_ON_STARTUP: 'yoink.sync.onStartup',
   LOG_LEVEL: 'yoink.log.level',

--- a/src/embedding/azureOpenAIProvider.ts
+++ b/src/embedding/azureOpenAIProvider.ts
@@ -1,0 +1,126 @@
+import { encoding_for_model, type Tiktoken } from 'tiktoken';
+import { EmbeddingProvider, estimateTokens } from './embeddingProvider';
+
+export interface AzureOpenAIProviderOptions {
+  apiKey: string;
+  endpoint: string;       // e.g. https://myresource.openai.azure.com
+  deploymentName: string;
+  apiVersion: string;     // e.g. 2024-02-01
+  dimensions: number;
+}
+
+/** Transient HTTP status codes that warrant a retry. */
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503]);
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 1000;
+
+export class AzureOpenAIEmbeddingProvider implements EmbeddingProvider {
+  readonly id = 'azure-openai';
+  readonly maxBatchSize = 2048;
+  readonly dimensions: number;
+
+  private readonly apiKey: string;
+  private readonly embedUrl: string;
+  private tokenizer: Tiktoken | null = null;
+
+  constructor(options: AzureOpenAIProviderOptions) {
+    this.apiKey = options.apiKey;
+    this.dimensions = options.dimensions;
+    const base = options.endpoint.replace(/\/$/, '');
+    this.embedUrl = `${base}/openai/deployments/${options.deploymentName}/embeddings?api-version=${options.apiVersion}`;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const results: number[][] = [];
+    for (let i = 0; i < texts.length; i += this.maxBatchSize) {
+      const batch = texts.slice(i, i + this.maxBatchSize);
+      const batchResults = await this.embedBatch(batch);
+      results.push(...batchResults);
+    }
+    return results;
+  }
+
+  private async embedBatch(texts: string[]): Promise<number[][]> {
+    const body = JSON.stringify({ input: texts });
+
+    const res = await this.fetchWithRetry(this.embedUrl, {
+      method: 'POST',
+      headers: {
+        'api-key': this.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Azure OpenAI API error ${res.status}: ${text}`);
+    }
+
+    const data = (await res.json()) as {
+      data: Array<{ embedding: number[]; index: number }>;
+    };
+
+    return data.data
+      .sort((a, b) => a.index - b.index)
+      .map((d) => d.embedding);
+  }
+
+  private async fetchWithRetry(url: string, init: RequestInit): Promise<Response> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const res = await fetch(url, init);
+
+        if (!RETRYABLE_STATUS_CODES.has(res.status) || attempt === MAX_RETRIES) {
+          return res;
+        }
+
+        const retryAfter = res.headers.get('Retry-After');
+        const waitMs = retryAfter
+          ? parseInt(retryAfter, 10) * 1000
+          : INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+
+        await sleep(waitMs);
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        if (attempt === MAX_RETRIES) break;
+        await sleep(INITIAL_BACKOFF_MS * Math.pow(2, attempt));
+      }
+    }
+
+    throw lastError ?? new Error('Request failed after retries');
+  }
+
+  countTokens(text: string): number {
+    try {
+      const enc = this.getTokenizer();
+      const tokens = enc.encode_ordinary(text);
+      return tokens.length;
+    } catch {
+      return estimateTokens(text);
+    }
+  }
+
+  private getTokenizer(): Tiktoken {
+    if (!this.tokenizer) {
+      // cl100k_base covers all current Azure OpenAI embedding models
+      this.tokenizer = encoding_for_model('text-embedding-3-small');
+    }
+    return this.tokenizer;
+  }
+
+  dispose(): void {
+    if (this.tokenizer) {
+      this.tokenizer.free();
+      this.tokenizer = null;
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/embedding/localProvider.ts
+++ b/src/embedding/localProvider.ts
@@ -1,0 +1,106 @@
+import { EmbeddingProvider, estimateTokens } from './embeddingProvider';
+
+export interface LocalProviderOptions {
+  baseUrl: string;   // e.g. http://localhost:11434/v1
+  model: string;     // e.g. nomic-embed-text
+  dimensions: number;
+  apiKey?: string;   // optional — some local servers require a key
+}
+
+/** Transient HTTP status codes that warrant a retry. */
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503]);
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 1000;
+
+export class LocalEmbeddingProvider implements EmbeddingProvider {
+  readonly id = 'local';
+  readonly maxBatchSize = 512;  // conservative for local hardware
+  readonly dimensions: number;
+
+  private readonly baseUrl: string;
+  private readonly model: string;
+  private readonly apiKey: string | undefined;
+
+  constructor(options: LocalProviderOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, '');
+    this.model = options.model;
+    this.dimensions = options.dimensions;
+    this.apiKey = options.apiKey;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const results: number[][] = [];
+    for (let i = 0; i < texts.length; i += this.maxBatchSize) {
+      const batch = texts.slice(i, i + this.maxBatchSize);
+      const batchResults = await this.embedBatch(batch);
+      results.push(...batchResults);
+    }
+    return results;
+  }
+
+  private async embedBatch(texts: string[]): Promise<number[][]> {
+    const body = JSON.stringify({ model: this.model, input: texts });
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    }
+
+    const res = await this.fetchWithRetry(`${this.baseUrl}/embeddings`, {
+      method: 'POST',
+      headers,
+      body,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Local embedding API error ${res.status}: ${text}`);
+    }
+
+    const data = (await res.json()) as {
+      data: Array<{ embedding: number[]; index: number }>;
+    };
+
+    return data.data
+      .sort((a, b) => a.index - b.index)
+      .map((d) => d.embedding);
+  }
+
+  private async fetchWithRetry(url: string, init: RequestInit): Promise<Response> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const res = await fetch(url, init);
+
+        if (!RETRYABLE_STATUS_CODES.has(res.status) || attempt === MAX_RETRIES) {
+          return res;
+        }
+
+        const retryAfter = res.headers.get('Retry-After');
+        const waitMs = retryAfter
+          ? parseInt(retryAfter, 10) * 1000
+          : INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+
+        await sleep(waitMs);
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        if (attempt === MAX_RETRIES) break;
+        await sleep(INITIAL_BACKOFF_MS * Math.pow(2, attempt));
+      }
+    }
+
+    throw lastError ?? new Error('Request failed after retries');
+  }
+
+  countTokens(text: string): number {
+    // Local models are arbitrary — tiktoken doesn't know them, so always estimate
+    return estimateTokens(text);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/embedding/registry.ts
+++ b/src/embedding/registry.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import { EmbeddingProvider } from './embeddingProvider';
 import { OpenAIEmbeddingProvider } from './openaiProvider';
+import { AzureOpenAIEmbeddingProvider } from './azureOpenAIProvider';
+import { LocalEmbeddingProvider } from './localProvider';
 import { SETTING_KEYS } from '../config/settingsSchema';
 
 export class EmbeddingProviderRegistry {
@@ -13,15 +15,21 @@ export class EmbeddingProviderRegistry {
     switch (providerType) {
       case 'openai':
         return this.createOpenAIProvider(config);
+      case 'azure-openai':
+        return this.createAzureProvider(config);
+      case 'local':
+        return this.createLocalProvider(config);
       default:
         throw new Error(`Unknown embedding provider: ${providerType}`);
     }
   }
 
+  // ── OpenAI ────────────────────────────────────────────────────────────────
+
   private async createOpenAIProvider(
     config: vscode.WorkspaceConfiguration,
   ): Promise<OpenAIEmbeddingProvider> {
-    const apiKey = await this.resolveApiKey();
+    const apiKey = await this.resolveOpenAIApiKey();
     if (!apiKey) {
       throw new Error(
         'OpenAI API key not configured. Run "Yoink: Set OpenAI API Key" or set the OPENAI_API_KEY environment variable.',
@@ -36,15 +44,13 @@ export class EmbeddingProviderRegistry {
   }
 
   async hasApiKey(): Promise<boolean> {
-    return (await this.resolveApiKey()) !== undefined;
+    return (await this.resolveOpenAIApiKey()) !== undefined;
   }
 
-  private async resolveApiKey(): Promise<string | undefined> {
-    // 1. SecretStorage (primary)
+  private async resolveOpenAIApiKey(): Promise<string | undefined> {
     const stored = await this.secretStorage.get('yoink.openai.apiKey');
     if (stored) return stored;
 
-    // 2. Environment variable (fallback)
     const envKey = process.env.OPENAI_API_KEY;
     if (envKey) return envKey;
 
@@ -57,5 +63,86 @@ export class EmbeddingProviderRegistry {
 
   async clearApiKey(): Promise<void> {
     await this.secretStorage.delete('yoink.openai.apiKey');
+  }
+
+  // ── Azure OpenAI ──────────────────────────────────────────────────────────
+
+  private async createAzureProvider(
+    config: vscode.WorkspaceConfiguration,
+  ): Promise<AzureOpenAIEmbeddingProvider> {
+    const apiKey = await this.resolveAzureApiKey();
+    if (!apiKey) {
+      throw new Error(
+        'Azure OpenAI API key not configured. Run "Yoink: Set Azure OpenAI API Key" or set the AZURE_OPENAI_API_KEY environment variable.',
+      );
+    }
+
+    const endpoint = config.get<string>(SETTING_KEYS.AZURE_ENDPOINT, '');
+    if (!endpoint) {
+      throw new Error(
+        'Azure OpenAI endpoint not configured. Set "yoink.embedding.azure.endpoint" in VS Code settings.',
+      );
+    }
+
+    const deploymentName = config.get<string>(SETTING_KEYS.AZURE_DEPLOYMENT_NAME, '');
+    if (!deploymentName) {
+      throw new Error(
+        'Azure OpenAI deployment name not configured. Set "yoink.embedding.azure.deploymentName" in VS Code settings.',
+      );
+    }
+
+    return new AzureOpenAIEmbeddingProvider({
+      apiKey,
+      endpoint,
+      deploymentName,
+      apiVersion: config.get<string>(SETTING_KEYS.AZURE_API_VERSION, '2024-02-01'),
+      dimensions: config.get<number>(SETTING_KEYS.AZURE_DIMENSIONS, 1536),
+    });
+  }
+
+  async hasAzureApiKey(): Promise<boolean> {
+    return (await this.resolveAzureApiKey()) !== undefined;
+  }
+
+  private async resolveAzureApiKey(): Promise<string | undefined> {
+    const stored = await this.secretStorage.get('yoink.azure.apiKey');
+    if (stored) return stored;
+
+    const envKey = process.env.AZURE_OPENAI_API_KEY;
+    if (envKey) return envKey;
+
+    return undefined;
+  }
+
+  async setAzureApiKey(key: string): Promise<void> {
+    await this.secretStorage.store('yoink.azure.apiKey', key);
+  }
+
+  async clearAzureApiKey(): Promise<void> {
+    await this.secretStorage.delete('yoink.azure.apiKey');
+  }
+
+  // ── Local ─────────────────────────────────────────────────────────────────
+
+  private async createLocalProvider(
+    config: vscode.WorkspaceConfiguration,
+  ): Promise<LocalEmbeddingProvider> {
+    const model = config.get<string>(SETTING_KEYS.LOCAL_MODEL, '');
+    if (!model) {
+      throw new Error(
+        'Local embedding model not configured. Set "yoink.embedding.local.model" in VS Code settings.',
+      );
+    }
+
+    // Optional API key for local servers that require one
+    const apiKey = await this.secretStorage.get('yoink.local.apiKey') ??
+      process.env.LOCAL_EMBEDDING_API_KEY;
+
+    return new LocalEmbeddingProvider({
+      baseUrl: config.get<string>(SETTING_KEYS.LOCAL_BASE_URL, 'http://localhost:11434/v1'),
+      model,
+      dimensions: config.get<number>(SETTING_KEYS.LOCAL_DIMENSIONS, 768),
+      apiKey: apiKey || undefined,
+    });
   }
 }

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -78,6 +78,18 @@ export function registerCommands(
       }
     }),
 
+    vscode.commands.registerCommand('yoink.setAzureApiKey', async () => {
+      const key = await vscode.window.showInputBox({
+        prompt: 'Enter your Azure OpenAI API key',
+        password: true,
+        ignoreFocusOut: true,
+      });
+      if (key) {
+        await providerRegistry.setAzureApiKey(key);
+        vscode.window.showInformationMessage('Azure OpenAI API key saved.');
+      }
+    }),
+
     // Tree-item context menu commands
     vscode.commands.registerCommand('yoink.syncDataSourceFromTree', async (item: DataSourceTreeItem) => {
       await dataSourceManager.sync(item.dataSource.id);

--- a/src/ui/sidebar/sidebarProvider.ts
+++ b/src/ui/sidebar/sidebarProvider.ts
@@ -76,11 +76,21 @@ export class EmbeddingTreeProvider implements vscode.TreeDataProvider<SidebarTre
   }
 
   async getChildren(): Promise<SidebarTreeItem[]> {
-    const model = vscode.workspace
-      .getConfiguration()
-      .get<string>(SETTING_KEYS.OPENAI_MODEL, 'text-embedding-3-small');
-    const hasKey = await this.embeddingRegistry.hasApiKey();
-    return [new EmbeddingTreeItem(model, hasKey)];
+    const config = vscode.workspace.getConfiguration();
+    const providerType = config.get<string>(SETTING_KEYS.EMBEDDING_PROVIDER, 'openai');
+
+    if (providerType === 'azure-openai') {
+      const deployment = config.get<string>(SETTING_KEYS.AZURE_DEPLOYMENT_NAME, '');
+      const hasKey = await this.embeddingRegistry.hasAzureApiKey();
+      return [new EmbeddingTreeItem(deployment || 'Azure OpenAI', hasKey, 'azure-openai')];
+    } else if (providerType === 'local') {
+      const model = config.get<string>(SETTING_KEYS.LOCAL_MODEL, 'local');
+      return [new EmbeddingTreeItem(model, true, 'local')];
+    } else {
+      const model = config.get<string>(SETTING_KEYS.OPENAI_MODEL, 'text-embedding-3-small');
+      const hasKey = await this.embeddingRegistry.hasApiKey();
+      return [new EmbeddingTreeItem(model, hasKey, 'openai')];
+    }
   }
 
   dispose(): void {

--- a/src/ui/sidebar/sidebarTreeItems.ts
+++ b/src/ui/sidebar/sidebarTreeItems.ts
@@ -95,18 +95,25 @@ export class DataSourceFileItem extends vscode.TreeItem {
 }
 
 export class EmbeddingTreeItem extends vscode.TreeItem {
-  constructor(model: string, hasKey: boolean) {
+  constructor(model: string, hasKey: boolean, provider: 'openai' | 'azure-openai' | 'local') {
     super(model, vscode.TreeItemCollapsibleState.None);
-    if (hasKey) {
+
+    if (provider === 'local') {
+      this.description = '$(check) Local model';
+      this.iconPath = new vscode.ThemeIcon('symbol-misc');
+      this.tooltip = `Embedding model: ${model}\nLocal model (no API key required)`;
+    } else if (hasKey) {
       this.description = '$(check) API key configured';
       this.iconPath = new vscode.ThemeIcon('symbol-misc');
       this.tooltip = `Embedding model: ${model}\nAPI key: configured`;
     } else {
+      const setKeyCommand = provider === 'azure-openai' ? 'yoink.setAzureApiKey' : 'yoink.setApiKey';
+      const providerLabel = provider === 'azure-openai' ? 'Azure OpenAI' : 'OpenAI';
       this.description = '$(warning) No API key — click to set';
       this.iconPath = new vscode.ThemeIcon('warning', new vscode.ThemeColor('problemsWarningIcon.foreground'));
-      this.tooltip = `Embedding model: ${model}\nAPI key: not configured\nClick to set your OpenAI API key`;
+      this.tooltip = `Embedding model: ${model}\nAPI key: not configured\nClick to set your ${providerLabel} API key`;
       this.command = {
-        command: 'yoink.setApiKey',
+        command: setKeyCommand,
         title: 'Set API Key',
       };
     }

--- a/test/unit/embedding/azureOpenAIProvider.test.ts
+++ b/test/unit/embedding/azureOpenAIProvider.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AzureOpenAIEmbeddingProvider } from '../../../src/embedding/azureOpenAIProvider';
+
+function makeProvider(
+  overrides: Partial<{
+    apiKey: string;
+    endpoint: string;
+    deploymentName: string;
+    apiVersion: string;
+    dimensions: number;
+  }> = {},
+) {
+  return new AzureOpenAIEmbeddingProvider({
+    apiKey: 'test-azure-key',
+    endpoint: 'https://myresource.openai.azure.com',
+    deploymentName: 'my-embedding-deployment',
+    apiVersion: '2024-02-01',
+    dimensions: 1536,
+    ...overrides,
+  });
+}
+
+function mockFetchResponse(data: object, status = 200, headers: Record<string, string> = {}) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: new Headers(headers),
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  });
+}
+
+function makeEmbeddingResponse(embeddings: number[][]) {
+  return {
+    data: embeddings.map((embedding, index) => ({ embedding, index })),
+    usage: { prompt_tokens: 10, total_tokens: 10 },
+  };
+}
+
+describe('AzureOpenAIEmbeddingProvider', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('constructor', () => {
+    it('sets dimensions from options', () => {
+      expect(makeProvider({ dimensions: 1536 }).dimensions).toBe(1536);
+      expect(makeProvider({ dimensions: 3072 }).dimensions).toBe(3072);
+    });
+
+    it('builds correct embed URL', () => {
+      globalThis.fetch = mockFetchResponse(makeEmbeddingResponse([[0.1]]));
+      const provider = makeProvider({
+        endpoint: 'https://myresource.openai.azure.com',
+        deploymentName: 'my-embed',
+        apiVersion: '2024-02-01',
+      });
+
+      provider.embed(['test']).catch(() => {}); // fire request
+
+      expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+        'https://myresource.openai.azure.com/openai/deployments/my-embed/embeddings?api-version=2024-02-01',
+      );
+    });
+
+    it('strips trailing slash from endpoint', async () => {
+      globalThis.fetch = mockFetchResponse(makeEmbeddingResponse([[0.1]]));
+      const provider = makeProvider({ endpoint: 'https://myresource.openai.azure.com/' });
+
+      await provider.embed(['test']);
+
+      const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(url).not.toContain('//openai');
+    });
+  });
+
+  describe('embed', () => {
+    it('returns empty array for empty input', async () => {
+      const provider = makeProvider();
+      expect(await provider.embed([])).toEqual([]);
+    });
+
+    it('uses api-key header (not Authorization Bearer)', async () => {
+      const embeddings = [[0.1, 0.2]];
+      globalThis.fetch = mockFetchResponse(makeEmbeddingResponse(embeddings));
+
+      await makeProvider({ apiKey: 'my-azure-key' }).embed(['hello']);
+
+      const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers['api-key']).toBe('my-azure-key');
+      expect(headers['Authorization']).toBeUndefined();
+    });
+
+    it('does not send model field in request body', async () => {
+      const embeddings = [[0.1, 0.2]];
+      globalThis.fetch = mockFetchResponse(makeEmbeddingResponse(embeddings));
+
+      await makeProvider().embed(['hello']);
+
+      const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+      const body = JSON.parse(init.body as string);
+      expect(body.model).toBeUndefined();
+      expect(body.input).toEqual(['hello']);
+    });
+
+    it('returns ordered embeddings', async () => {
+      const embeddings = [[0.3, 0.4], [0.1, 0.2]];
+      // Return out of order to test sorting
+      const response = {
+        data: [
+          { embedding: [0.3, 0.4], index: 1 },
+          { embedding: [0.1, 0.2], index: 0 },
+        ],
+      };
+      globalThis.fetch = mockFetchResponse(response);
+
+      const result = await makeProvider().embed(['first', 'second']);
+
+      expect(result[0]).toEqual([0.1, 0.2]);
+      expect(result[1]).toEqual([0.3, 0.4]);
+    });
+
+    it('throws on non-retryable error', async () => {
+      globalThis.fetch = mockFetchResponse({ error: 'Unauthorized' }, 401);
+
+      await expect(makeProvider().embed(['test'])).rejects.toThrow('Azure OpenAI API error 401');
+    });
+
+    it('retries on 429 and eventually throws', async () => {
+      globalThis.fetch = mockFetchResponse({ error: 'Rate limited' }, 429);
+      vi.useFakeTimers();
+
+      // Attach rejection handler before advancing timers to avoid unhandled rejection
+      const rejectionPromise = expect(makeProvider().embed(['test'])).rejects.toThrow('Azure OpenAI API error 429');
+      await vi.runAllTimersAsync();
+      await rejectionPromise;
+
+      vi.useRealTimers();
+    }, 10000);
+  });
+
+  describe('countTokens', () => {
+    it('returns a positive number for non-empty text', () => {
+      const count = makeProvider().countTokens('hello world');
+      expect(count).toBeGreaterThan(0);
+    });
+
+    it('returns 0 for empty string', () => {
+      expect(makeProvider().countTokens('')).toBe(0);
+    });
+  });
+
+  describe('dispose', () => {
+    it('can be called without error', () => {
+      const provider = makeProvider();
+      expect(() => provider.dispose()).not.toThrow();
+    });
+
+    it('can be called multiple times safely', () => {
+      const provider = makeProvider();
+      provider.dispose();
+      expect(() => provider.dispose()).not.toThrow();
+    });
+  });
+});

--- a/test/unit/embedding/localProvider.test.ts
+++ b/test/unit/embedding/localProvider.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { LocalEmbeddingProvider } from '../../../src/embedding/localProvider';
+
+function makeProvider(
+  overrides: Partial<{
+    baseUrl: string;
+    model: string;
+    dimensions: number;
+    apiKey: string;
+  }> = {},
+) {
+  return new LocalEmbeddingProvider({
+    baseUrl: 'http://localhost:11434/v1',
+    model: 'nomic-embed-text',
+    dimensions: 768,
+    ...overrides,
+  });
+}
+
+function mockFetchResponse(data: object, status = 200, headers: Record<string, string> = {}) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: new Headers(headers),
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  });
+}
+
+function makeEmbeddingResponse(embeddings: number[][]) {
+  return {
+    data: embeddings.map((embedding, index) => ({ embedding, index })),
+    usage: { prompt_tokens: 10, total_tokens: 10 },
+  };
+}
+
+describe('LocalEmbeddingProvider', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('constructor', () => {
+    it('sets dimensions from options', () => {
+      expect(makeProvider({ dimensions: 768 }).dimensions).toBe(768);
+      expect(makeProvider({ dimensions: 384 }).dimensions).toBe(384);
+    });
+
+    it('has conservative maxBatchSize of 512', () => {
+      expect(makeProvider().maxBatchSize).toBe(512);
+    });
+
+    it('has id of "local"', () => {
+      expect(makeProvider().id).toBe('local');
+    });
+
+    it('strips trailing slash from baseUrl', async () => {
+      globalThis.fetch = mockFetchResponse(makeEmbeddingResponse([[0.1]]));
+      await makeProvider({ baseUrl: 'http://localhost:11434/v1/' }).embed(['test']);
+
+      const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(url).toBe('http://localhost:11434/v1/embeddings');
+    });
+  });
+
+  describe('embed', () => {
+    it('returns empty array for empty input', async () => {
+      expect(await makeProvider().embed([])).toEqual([]);
+    });
+
+    it('sends model name and input in request body', async () => {
+      globalThis.fetch = mockFetchResponse(makeEmbeddingResponse([[0.1, 0.2]]));
+
+      await makeProvider({ model: 'nomic-embed-text' }).embed(['hello']);
+
+      const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+      const body = JSON.parse(init.body as string);
+      expect(body.model).toBe('nomic-embed-text');
+      expect(body.input).toEqual(['hello']);
+    });
+
+    it('does not send Authorization header when no apiKey', async () => {
+      globalThis.fetch = mockFetchResponse(makeEmbeddingResponse([[0.1]]));
+
+      await makeProvider().embed(['hello']);
+
+      const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Authorization']).toBeUndefined();
+    });
+
+    it('sends Authorization Bearer header when apiKey is provided', async () => {
+      globalThis.fetch = mockFetchResponse(makeEmbeddingResponse([[0.1]]));
+
+      await makeProvider({ apiKey: 'my-local-key' }).embed(['hello']);
+
+      const init = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Authorization']).toBe('Bearer my-local-key');
+    });
+
+    it('returns ordered embeddings', async () => {
+      const response = {
+        data: [
+          { embedding: [0.3, 0.4], index: 1 },
+          { embedding: [0.1, 0.2], index: 0 },
+        ],
+      };
+      globalThis.fetch = mockFetchResponse(response);
+
+      const result = await makeProvider().embed(['first', 'second']);
+
+      expect(result[0]).toEqual([0.1, 0.2]);
+      expect(result[1]).toEqual([0.3, 0.4]);
+    });
+
+    it('throws on API error', async () => {
+      globalThis.fetch = mockFetchResponse({ error: 'model not found' }, 404);
+
+      await expect(makeProvider().embed(['test'])).rejects.toThrow('Local embedding API error 404');
+    });
+
+    it('retries on 429 and eventually throws', async () => {
+      globalThis.fetch = mockFetchResponse({ error: 'Rate limited' }, 429);
+      vi.useFakeTimers();
+
+      // Attach rejection handler before advancing timers to avoid unhandled rejection
+      const rejectionPromise = expect(makeProvider().embed(['test'])).rejects.toThrow('Local embedding API error 429');
+      await vi.runAllTimersAsync();
+      await rejectionPromise;
+
+      vi.useRealTimers();
+    }, 10000);
+
+    it('splits large batches at maxBatchSize', async () => {
+      const singleEmbedding = [0.1, 0.2];
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => ({
+          data: [{ embedding: singleEmbedding, index: 0 }],
+        }),
+        text: async () => '',
+      });
+
+      // 513 texts should trigger two fetch calls (512 + 1)
+      const texts = Array.from({ length: 513 }, (_, i) => `text ${i}`);
+      await makeProvider().embed(texts);
+
+      expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    });
+  });
+
+  describe('countTokens', () => {
+    it('always uses character-based estimation', () => {
+      const provider = makeProvider();
+      // estimateTokens uses Math.ceil(text.length / 4)
+      expect(provider.countTokens('hello')).toBe(Math.ceil('hello'.length / 4));
+      expect(provider.countTokens('hello world')).toBe(Math.ceil('hello world'.length / 4));
+    });
+
+    it('returns 0 for empty string', () => {
+      expect(makeProvider().countTokens('')).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Extends the embedding system beyond OpenAI-only to support:

- Azure OpenAI: uses deployment-based URL
  ({endpoint}/openai/deployments/{name}/embeddings?api-version=...),
  api-key header auth, configurable dimensions, and tiktoken token
  counting. API key stored in SecretStorage (yoink.azure.apiKey) with
  AZURE_OPENAI_API_KEY env fallback. New command: yoink.setAzureApiKey.

- Local (Ollama/OpenAI-compatible): sends to {baseUrl}/embeddings with
  optional Bearer auth, configurable model and dimensions, and
  estimateTokens() since tiktoken doesn't know arbitrary local models.
  Conservative maxBatchSize of 512 for local hardware.

New VS Code settings: yoink.embedding.azure.{endpoint,deploymentName,
apiVersion,dimensions} and yoink.embedding.local.{baseUrl,model,dimensions}.

Sidebar embedding view and EmbeddingTreeItem updated to display correct
provider info and set-key commands for all three providers.

https://claude.ai/code/session_019TmBXJdSCSoh62W17LM6LZ