### PR TITLE
Add AST-based chunking strategy via Tree-sitter WASM

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,6 +13,9 @@ node_modules/**
 !node_modules/file-uri-to-path/**
 !node_modules/sqlite-vec/**
 !node_modules/sqlite-vec-*/**
+!node_modules/@vscode/tree-sitter-wasm/**
+!node_modules/web-tree-sitter/**
+!dist/queries/**
 tsconfig.json
 vitest.config.ts
 eslint.config.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,11 +69,80 @@ Yoink is a VS Code extension that indexes GitHub repositories into a local SQLit
 
 ```
 GitHub Trees API → fileFilter (glob) → GitHub Blobs API
-  → chunker (512-token fixed-size, 64-token overlap, tiktoken)
+  → chunker (strategy chosen by data source preset)
   → OpenAI embedding API → better-sqlite3 (chunks + vec0)
 ```
 
 `src/ingestion/pipeline.ts` orchestrates this. A concurrent queue (limit: 3 parallel data sources) is managed inside the pipeline. Status transitions (`queued → indexing → ready | error`) are written to both the SQLite `data_sources` table and `yoink.json`.
+
+### Chunking
+
+The chunker (`src/ingestion/chunker.ts`) dispatches on a `ChunkingStrategy`, chosen **per data source** by the `RepoTypePreset` (`src/config/repoTypePresets.ts`). All files in a given ingest run go through the same strategy — there is no per-file strategy routing at the top level. Files that don't fit are handled by each strategy's own fallback.
+
+| Strategy           | What it does                                                              | Used by preset(s)                          |
+|--------------------|---------------------------------------------------------------------------|--------------------------------------------|
+| `token-split`      | Fixed-size token windows with overlap (default 512 / 64).                 | `general`, `openapi-specs`                 |
+| `file-level`       | One chunk per file. Good for action.yml, workflow files.                  | `github-actions-library`, `cicd-workflows` |
+| `markdown-heading` | Splits on `#` headings; oversized sections fall back to `token-split`.    | `documentation`                            |
+| `ast-based`        | Tree-sitter — one chunk per top-level function, method, or class.         | `source-code`                              |
+
+`ast-based` is the only strategy that does file-type dispatch internally:
+- `languageDetection.ts` maps the extension to a supported language
+  (TypeScript, TSX, JS/JSX, Python, Go, Java, C#, Rust, Ruby).
+- Unknown extensions, parse failures, or files with no captured definitions
+  fall back to `chunkByTokens` for the whole file — the `ast-based` preset
+  is therefore safe to point at polyglot repos.
+- Each method chunk is prefixed with a comment header naming its enclosing
+  class (`// Class: UserService` / `# Class: Greeter`). Go uses the receiver,
+  Rust uses the `impl` target type.
+- Classes that contain methods are not emitted as their own chunk (the
+  methods cover them, prefixed with the class name); empty classes /
+  data classes / interfaces emit as a single chunk.
+- Oversized definitions are split via the strategy's `fallback`
+  (token-split), with line numbers offset to the node's position so search
+  results still point at the right lines.
+
+`Chunker.chunkFile` is `async` because `ast-based` lazy-loads WASM grammars
+on first use. The other strategies await trivially.
+
+#### How to add a new strategy
+
+1. Add the literal to `ChunkingStrategy` in `src/ingestion/chunker.ts`.
+2. Add a private method to `Chunker` implementing it; dispatch from
+   `chunkFile` with a single `if` branch.
+3. If it needs external dependencies (e.g. `ast-based` needs `ParserRegistry`),
+   add an optional field to `ChunkerOptions`, thread it through
+   `pipeline.ts` and `extension.ts`, and assert presence in the dispatch
+   branch.
+4. Add a preset to `REPO_TYPE_PRESETS` that uses the new strategy (and
+   matching `includePatterns`).
+5. Add unit tests in `test/unit/ingestion/`.
+
+#### How to add a new language to the AST strategy
+
+1. Verify the WASM grammar is available in
+   `node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter-<lang>.wasm`
+   (or add a different source).
+2. Extend `SupportedLanguage` in `src/ingestion/languageDetection.ts` and
+   map any file extensions in `EXTENSION_TO_LANGUAGE`. Set the comment
+   prefix in `lineCommentPrefix` if it isn't `//`.
+3. Add a query file at `src/chunking/queries/<lang>.scm` capturing
+   `@definition.function`, `@definition.method`, and/or `@definition.class`.
+4. Add the WASM filename to `WASM_FILENAME` in
+   `src/ingestion/parserRegistry.ts`.
+5. Add the language's class-like node types to `CONTAINER_TYPES` in
+   `src/ingestion/astChunker.ts` so methods get a parent-class prefix.
+   For languages without classes (Go-style methods), special-case in
+   `resolveContainerName`.
+6. Update the `'source-code'` preset's `includePatterns` to include the
+   new extension.
+7. Add a fixture under `test/fixtures/ast/` and assertions in
+   `test/unit/ingestion/astChunker.test.ts`.
+
+Queries live in `src/chunking/queries/` and are copied to `dist/queries/`
+by `scripts/copy-queries.mjs` (chained from `npm run build`). The VSIX
+packaging step (`.vscodeignore`) ships both `dist/queries/**` and
+`node_modules/@vscode/tree-sitter-wasm/**`.
 
 ### Query Path (read path)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Yoink is a VS Code extension that indexes GitHub repositories into a local SQLit
 
 ```
 GitHub Trees API → fileFilter (glob) → GitHub Blobs API
-  → chunker (strategy chosen by data source preset)
+  → chunker (strategy chosen per file by Chunker.routeStrategy)
   → OpenAI embedding API → better-sqlite3 (chunks + vec0)
 ```
 
@@ -77,21 +77,34 @@ GitHub Trees API → fileFilter (glob) → GitHub Blobs API
 
 ### Chunking
 
-The chunker (`src/ingestion/chunker.ts`) dispatches on a `ChunkingStrategy`, chosen **per data source** by the `RepoTypePreset` (`src/config/repoTypePresets.ts`). All files in a given ingest run go through the same strategy — there is no per-file strategy routing at the top level. Files that don't fit are handled by each strategy's own fallback.
+The chunker (`src/ingestion/chunker.ts`) picks a strategy **per file**, based on path/extension. A single `Chunker` instance handles every file in an ingest run — polyglot repos (code + docs + workflows) are chunked correctly without any per-data-source configuration. `RepoTypePreset` (`src/config/repoTypePresets.ts`) only drives the include-pattern filter; it has no strategy field.
 
-| Strategy           | What it does                                                              | Used by preset(s)                          |
-|--------------------|---------------------------------------------------------------------------|--------------------------------------------|
-| `token-split`      | Fixed-size token windows with overlap (default 512 / 64).                 | `general`, `openapi-specs`                 |
-| `file-level`       | One chunk per file. Good for action.yml, workflow files.                  | `github-actions-library`, `cicd-workflows` |
-| `markdown-heading` | Splits on `#` headings; oversized sections fall back to `token-split`.    | `documentation`                            |
-| `ast-based`        | Tree-sitter — one chunk per top-level function, method, or class.         | `source-code`                              |
+Routing (`Chunker.routeStrategy`, in order):
 
-`ast-based` is the only strategy that does file-type dispatch internally:
+| Match                                         | Strategy           |
+|-----------------------------------------------|--------------------|
+| `*.md`, `*.mdx`                               | `markdown-heading` |
+| `.github/workflows/*.yml` / `*.yaml`          | `file-level`       |
+| `action.yml` / `action.yaml` (any depth)      | `file-level`       |
+| Extension in `languageDetection` table        | `ast-based`        |
+| Everything else                               | `token-split`      |
+
+Strategy behaviors:
+
+| Strategy           | What it does                                                              |
+|--------------------|---------------------------------------------------------------------------|
+| `token-split`      | Fixed-size token windows with overlap (default 512 / 64).                 |
+| `file-level`       | One chunk per file. Good for action.yml and workflow YAML.                |
+| `markdown-heading` | Splits on `#` headings; oversized sections fall back to `token-split`.    |
+| `ast-based`        | Tree-sitter — one chunk per top-level function, method, or class.         |
+
+`ast-based` details:
 - `languageDetection.ts` maps the extension to a supported language
   (TypeScript, TSX, JS/JSX, Python, Go, Java, C#, Rust, Ruby).
-- Unknown extensions, parse failures, or files with no captured definitions
-  fall back to `chunkByTokens` for the whole file — the `ast-based` preset
-  is therefore safe to point at polyglot repos.
+- Parse failures or files with no captured definitions fall back to
+  `chunkByTokens` for the whole file.
+- When `parserRegistry` is absent (e.g. in unit tests), routing degrades
+  AST files to `token-split` rather than throwing.
 - Each method chunk is prefixed with a comment header naming its enclosing
   class (`// Class: UserService` / `# Class: Greeter`). Go uses the receiver,
   Rust uses the `impl` target type.
@@ -99,24 +112,33 @@ The chunker (`src/ingestion/chunker.ts`) dispatches on a `ChunkingStrategy`, cho
   methods cover them, prefixed with the class name); empty classes /
   data classes / interfaces emit as a single chunk.
 - Oversized definitions are split via the strategy's `fallback`
-  (token-split), with line numbers offset to the node's position so search
-  results still point at the right lines.
+  (token-split), with line numbers offset to the node's position.
 
 `Chunker.chunkFile` is `async` because `ast-based` lazy-loads WASM grammars
 on first use. The other strategies await trivially.
+
+`ChunkerOptions` exposes an optional `strategy` field that **forces** a
+single strategy for every file. This is intended for tests; production code
+in `pipeline.ts` leaves it unset so routing is used.
+
+#### How to change the routing table
+
+`Chunker.routeStrategy` in `src/ingestion/chunker.ts` is the single source of
+truth. Add a branch above the default `token-split` return; cover it in
+`test/unit/ingestion/chunker.test.ts` under the `Chunker.routeStrategy`
+block.
 
 #### How to add a new strategy
 
 1. Add the literal to `ChunkingStrategy` in `src/ingestion/chunker.ts`.
 2. Add a private method to `Chunker` implementing it; dispatch from
-   `chunkFile` with a single `if` branch.
-3. If it needs external dependencies (e.g. `ast-based` needs `ParserRegistry`),
-   add an optional field to `ChunkerOptions`, thread it through
-   `pipeline.ts` and `extension.ts`, and assert presence in the dispatch
-   branch.
-4. Add a preset to `REPO_TYPE_PRESETS` that uses the new strategy (and
-   matching `includePatterns`).
-5. Add unit tests in `test/unit/ingestion/`.
+   `Chunker#dispatch` with a single `if` branch.
+3. Add a routing rule to `Chunker.routeStrategy` (or rely on the forced
+   `strategy` option for test-only use).
+4. If it needs external dependencies, add an optional field to
+   `ChunkerOptions`, thread it through `pipeline.ts` and `extension.ts`,
+   and handle absence gracefully in the routing path.
+5. Add unit tests in `test/unit/ingestion/chunker.test.ts`.
 
 #### How to add a new language to the AST strategy
 
@@ -134,8 +156,9 @@ on first use. The other strategies await trivially.
    `src/ingestion/astChunker.ts` so methods get a parent-class prefix.
    For languages without classes (Go-style methods), special-case in
    `resolveContainerName`.
-6. Update the `'source-code'` preset's `includePatterns` to include the
-   new extension.
+6. Update the `source-code` preset's `includePatterns` to include the
+   new extension (the router picks it up automatically via
+   `detectLanguage`).
 7. Add a fixture under `test/fixtures/ast/` and assertions in
    `test/unit/ingestion/astChunker.test.ts`.
 
@@ -143,6 +166,24 @@ Queries live in `src/chunking/queries/` and are copied to `dist/queries/`
 by `scripts/copy-queries.mjs` (chained from `npm run build`). The VSIX
 packaging step (`.vscodeignore`) ships both `dist/queries/**` and
 `node_modules/@vscode/tree-sitter-wasm/**`.
+
+### Repo Type Presets
+
+`REPO_TYPE_PRESETS` (`src/config/repoTypePresets.ts`) is a user-facing
+catalog of default include patterns and tool descriptions — not a strategy
+selector. Each preset answers "what files do I want indexed?":
+
+| Preset                    | Include filter                                                                  |
+|---------------------------|---------------------------------------------------------------------------------|
+| `general`                 | no filter (everything passes)                                                   |
+| `documentation`           | `**/*.md`, `**/*.mdx`, `docs/**`, `wiki/**`                                     |
+| `source-code`             | `**/*.{ts,tsx,js,jsx,mjs,cjs,py,go,java,cs,rs,rb,md,mdx}` — code + inline docs  |
+| `github-actions-library`  | `**/action.yml`, `**/action.yaml`, `**/README.md`                               |
+| `cicd-workflows`          | `.github/workflows/**`                                                          |
+| `openapi-specs`           | `**/*.yaml`, `**/*.yml`, `**/*.json`, `openapi/**`, `swagger/**`                |
+
+A single data source can mix file types — e.g. `source-code` indexes both
+TypeScript and Markdown, and each file gets its own strategy via the router.
 
 ### Query Path (read path)
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,33 @@ Yoink indexes GitHub repositories into a local SQLite vector database and expose
 ## Features
 
 - Index any public or private GitHub repository as a searchable data source
+- Multiple chunking strategies — fixed-size token windows for general content,
+  markdown-heading splits for docs, file-level for action.yml / workflows, and
+  AST-based splitting (Tree-sitter) that produces one chunk per function,
+  method, or class for source code
 - Vector search via `sqlite-vec` (brute-force KNN, fully local)
 - Automatic delta sync — only re-indexes changed files since last sync
 - Multiple tools, each scoped to a subset of data sources
 - OpenAI-compatible embedding API (defaults to `text-embedding-3-small`)
+
+### Repo types
+
+When you add a repository, you pick a type that drives the include filters
+and the chunking strategy used for every file in the data source.
+
+| Type                       | Strategy           | Best for                                 |
+|----------------------------|--------------------|------------------------------------------|
+| `general`                  | `token-split`      | Mixed-content repos, default             |
+| `documentation`            | `markdown-heading` | Repos dominated by `.md` / `docs/**`     |
+| `source-code`              | `ast-based`        | TS/TSX, JS/JSX, Python, Go, Java, C#, Rust, Ruby |
+| `github-actions-library`   | `file-level`       | `action.yml` collections                 |
+| `cicd-workflows`           | `file-level`       | `.github/workflows/**`                   |
+| `openapi-specs`            | `token-split`      | YAML/JSON API specs                      |
+
+For `source-code`, the AST chunker prefixes each method with its enclosing
+class (e.g. `// Class: UserService`) so the embedded text carries context.
+Files with extensions outside the supported language set fall back to
+token-split, so polyglot code repos work without manual configuration.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Yoink indexes GitHub repositories into a local SQLite vector database and expose
 ## Features
 
 - Index any public or private GitHub repository as a searchable data source
-- Multiple chunking strategies — fixed-size token windows for general content,
-  markdown-heading splits for docs, file-level for action.yml / workflows, and
-  AST-based splitting (Tree-sitter) that produces one chunk per function,
-  method, or class for source code
+- Per-file chunking — markdown is split on headings, source code is split on
+  functions/methods/classes via Tree-sitter (TS/TSX, JS/JSX, Python, Go, Java,
+  C#, Rust, Ruby), `action.yml` and workflow files are kept whole, and
+  everything else falls back to fixed-size token windows
 - Vector search via `sqlite-vec` (brute-force KNN, fully local)
 - Automatic delta sync — only re-indexes changed files since last sync
 - Multiple tools, each scoped to a subset of data sources
@@ -18,22 +18,37 @@ Yoink indexes GitHub repositories into a local SQLite vector database and expose
 
 ### Repo types
 
-When you add a repository, you pick a type that drives the include filters
-and the chunking strategy used for every file in the data source.
+When you add a repository, you pick a type that drives the include filter —
+i.e. which files get indexed. The chunking strategy is chosen **per file** by
+the chunker based on path/extension, not per data source, so a single
+`source-code` data source can mix TypeScript code and Markdown docs and each
+file is chunked appropriately.
 
-| Type                       | Strategy           | Best for                                 |
-|----------------------------|--------------------|------------------------------------------|
-| `general`                  | `token-split`      | Mixed-content repos, default             |
-| `documentation`            | `markdown-heading` | Repos dominated by `.md` / `docs/**`     |
-| `source-code`              | `ast-based`        | TS/TSX, JS/JSX, Python, Go, Java, C#, Rust, Ruby |
-| `github-actions-library`   | `file-level`       | `action.yml` collections                 |
-| `cicd-workflows`           | `file-level`       | `.github/workflows/**`                   |
-| `openapi-specs`            | `token-split`      | YAML/JSON API specs                      |
+| Type                       | Indexes                                                                |
+|----------------------------|------------------------------------------------------------------------|
+| `general`                  | everything (no filter)                                                 |
+| `documentation`            | `**/*.md`, `**/*.mdx`, `docs/**`, `wiki/**`                            |
+| `source-code`              | TS/TSX, JS/JSX, Python, Go, Java, C#, Rust, Ruby — plus `.md`/`.mdx`   |
+| `github-actions-library`   | `action.yml` / `action.yaml` and `README.md` at any depth              |
+| `cicd-workflows`           | `.github/workflows/**`                                                 |
+| `openapi-specs`            | YAML/JSON spec files, `openapi/**`, `swagger/**`                       |
 
-For `source-code`, the AST chunker prefixes each method with its enclosing
-class (e.g. `// Class: UserService`) so the embedded text carries context.
-Files with extensions outside the supported language set fall back to
-token-split, so polyglot code repos work without manual configuration.
+### Chunking
+
+Strategy is chosen per file:
+
+| File pattern                               | Strategy                                                      |
+|--------------------------------------------|---------------------------------------------------------------|
+| `*.md`, `*.mdx`                            | split on `#` headings (oversized sections fall back to tokens)|
+| `.github/workflows/*.{yml,yaml}`           | one chunk per file                                            |
+| `action.yml` / `action.yaml` (any depth)   | one chunk per file                                            |
+| Supported source languages (see above)     | one chunk per function / method / class (Tree-sitter AST)     |
+| Everything else                            | fixed-size token windows with overlap                         |
+
+AST method chunks are prefixed with their enclosing class (e.g.
+`// Class: UserService`) so the embedded text carries context. Parse failures
+or files with no definitions fall back to token-split, so polyglot repos
+work without manual configuration.
 
 ## Requirements
 

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -11,6 +11,7 @@ const buildOptions = {
     'vscode',
     'better-sqlite3',
     'sqlite-vec',
+    'web-tree-sitter',
   ],
   format: 'cjs',
   platform: 'node',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@vscode/tree-sitter-wasm": "^0.3.1",
         "better-sqlite3": "^12.8.0",
         "minimatch": "^10.0.1",
         "sqlite-vec": "^0.1.6",
-        "tiktoken": "^1.0.18"
+        "tiktoken": "^1.0.18",
+        "web-tree-sitter": "^0.26.8"
       },
       "devDependencies": {
         "@electron/rebuild": "^4.0.3",
@@ -2278,6 +2280,12 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vscode/tree-sitter-wasm": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@vscode/tree-sitter-wasm/-/tree-sitter-wasm-0.3.1.tgz",
+      "integrity": "sha512-RJFoomET6FajjG511fmQxeBQfU6M24a0aFZPqpid+ttIxanWf1VGytBG0UmsGjt07qmIPJS8U31D+aecuCucsQ==",
+      "license": "MIT"
     },
     "node_modules/@vscode/vsce": {
       "version": "3.7.1",
@@ -8214,6 +8222,12 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.8",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.8.tgz",
+      "integrity": "sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==",
+      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -218,7 +218,13 @@
         "name": "yoink-search",
         "toolReferenceName": "yoink",
         "canBeReferencedInPrompt": true,
-        "tags": ["yoink", "search", "rag", "github", "codebase"],
+        "tags": [
+          "yoink",
+          "search",
+          "rag",
+          "github",
+          "codebase"
+        ],
         "displayName": "Yoink: Search Repositories",
         "userDescription": "Search your indexed GitHub repositories for relevant code, documentation, or knowledge.",
         "modelDescription": "Search indexed GitHub repositories using vector similarity. Returns relevant code snippets and documentation. Use 'repository' to filter by a specific repo (owner/repo format), or 'tool' to use a configured tool scope. Call yoink-list first to discover available repositories and tools.",
@@ -238,14 +244,21 @@
               "description": "Optional: use a configured Yoink tool name to search only its assigned repositories. Get available tool names from yoink-list."
             }
           },
-          "required": ["query"]
+          "required": [
+            "query"
+          ]
         }
       },
       {
         "name": "yoink-list",
         "toolReferenceName": "yoink-list",
         "canBeReferencedInPrompt": true,
-        "tags": ["yoink", "list", "discover", "repositories"],
+        "tags": [
+          "yoink",
+          "list",
+          "discover",
+          "repositories"
+        ],
         "displayName": "Yoink: List Data Sources",
         "userDescription": "List all indexed GitHub repositories and configured search tools in Yoink.",
         "modelDescription": "List all data sources (GitHub repositories) and tools currently indexed and available in Yoink. Call this first to discover what repositories are available before searching. Returns repository names, branches, status, file/chunk counts, and any configured tool scopes.",
@@ -257,7 +270,12 @@
       {
         "name": "yoink-get-file",
         "toolReferenceName": "yoinkGetFile",
-        "tags": ["yoink", "github", "file", "code"],
+        "tags": [
+          "yoink",
+          "github",
+          "file",
+          "code"
+        ],
         "displayName": "Yoink: Get File",
         "userDescription": "Fetch the full content of a file from an indexed GitHub repository.",
         "modelDescription": "Fetch the full or partial content of a file from an indexed GitHub repository. Use this when search results reference a file and you need more context than the returned chunk provides. Provide startLine and endLine to fetch a specific section of a large file.",
@@ -281,13 +299,16 @@
               "description": "Optional. Last line to return (1-indexed). Use line numbers from search results."
             }
           },
-          "required": ["repository", "filePath"]
+          "required": [
+            "repository",
+            "filePath"
+          ]
         }
       }
     ]
   },
   "scripts": {
-    "build": "node esbuild.mjs",
+    "build": "node esbuild.mjs && node scripts/copy-queries.mjs",
     "watch": "node esbuild.mjs --watch",
     "compile": "tsc --noEmit",
     "lint": "eslint src/",
@@ -298,16 +319,18 @@
     "rebuild:native": "electron-rebuild -v 39.8.3 --arch arm64 --only better-sqlite3,sqlite-vec"
   },
   "dependencies": {
+    "@vscode/tree-sitter-wasm": "^0.3.1",
     "better-sqlite3": "^12.8.0",
     "minimatch": "^10.0.1",
     "sqlite-vec": "^0.1.6",
-    "tiktoken": "^1.0.18"
+    "tiktoken": "^1.0.18",
+    "web-tree-sitter": "^0.26.8"
   },
   "optionalDependencies": {
     "sqlite-vec-darwin-arm64": "^0.1.9",
     "sqlite-vec-darwin-x64": "^0.1.9",
-    "sqlite-vec-linux-x64": "^0.1.9",
     "sqlite-vec-linux-arm64": "^0.1.9",
+    "sqlite-vec-linux-x64": "^0.1.9",
     "sqlite-vec-windows-x64": "^0.1.9"
   },
   "devDependencies": {

--- a/scripts/copy-queries.mjs
+++ b/scripts/copy-queries.mjs
@@ -1,0 +1,20 @@
+// Copies tree-sitter query files from src/chunking/queries/ into
+// dist/queries/ so they ship with the VSIX. Invoked from `npm run build`.
+
+import { mkdir, readdir, copyFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const srcDir = join(repoRoot, 'src', 'chunking', 'queries');
+const outDir = join(repoRoot, 'dist', 'queries');
+
+await mkdir(outDir, { recursive: true });
+
+const entries = await readdir(srcDir);
+const queries = entries.filter((name) => name.endsWith('.scm'));
+for (const name of queries) {
+  await copyFile(join(srcDir, name), join(outDir, name));
+}
+console.log(`copy-queries: wrote ${queries.length} .scm files to ${outDir}`);

--- a/src/chunking/queries/csharp.scm
+++ b/src/chunking/queries/csharp.scm
@@ -1,0 +1,8 @@
+(class_declaration) @definition.class
+(interface_declaration) @definition.class
+(struct_declaration) @definition.class
+(enum_declaration) @definition.class
+(record_declaration) @definition.class
+(method_declaration) @definition.method
+(constructor_declaration) @definition.method
+(destructor_declaration) @definition.method

--- a/src/chunking/queries/go.scm
+++ b/src/chunking/queries/go.scm
@@ -1,0 +1,3 @@
+(function_declaration) @definition.function
+(method_declaration) @definition.method
+(type_declaration) @definition.class

--- a/src/chunking/queries/java.scm
+++ b/src/chunking/queries/java.scm
@@ -1,0 +1,6 @@
+(class_declaration) @definition.class
+(interface_declaration) @definition.class
+(enum_declaration) @definition.class
+(record_declaration) @definition.class
+(method_declaration) @definition.method
+(constructor_declaration) @definition.method

--- a/src/chunking/queries/javascript.scm
+++ b/src/chunking/queries/javascript.scm
@@ -1,0 +1,4 @@
+(function_declaration) @definition.function
+(generator_function_declaration) @definition.function
+(class_declaration) @definition.class
+(method_definition) @definition.method

--- a/src/chunking/queries/python.scm
+++ b/src/chunking/queries/python.scm
@@ -1,0 +1,3 @@
+(function_definition) @definition.function
+(class_definition) @definition.class
+(decorated_definition) @definition.decorated

--- a/src/chunking/queries/ruby.scm
+++ b/src/chunking/queries/ruby.scm
@@ -1,0 +1,4 @@
+(method) @definition.method
+(singleton_method) @definition.method
+(class) @definition.class
+(module) @definition.class

--- a/src/chunking/queries/rust.scm
+++ b/src/chunking/queries/rust.scm
@@ -1,0 +1,5 @@
+(function_item) @definition.function
+(struct_item) @definition.class
+(enum_item) @definition.class
+(trait_item) @definition.class
+(impl_item) @definition.impl

--- a/src/chunking/queries/tsx.scm
+++ b/src/chunking/queries/tsx.scm
@@ -1,0 +1,6 @@
+(function_declaration) @definition.function
+(generator_function_declaration) @definition.function
+(class_declaration) @definition.class
+(interface_declaration) @definition.class
+(method_definition) @definition.method
+(abstract_method_signature) @definition.method

--- a/src/chunking/queries/typescript.scm
+++ b/src/chunking/queries/typescript.scm
@@ -1,0 +1,6 @@
+(function_declaration) @definition.function
+(generator_function_declaration) @definition.function
+(class_declaration) @definition.class
+(interface_declaration) @definition.class
+(method_definition) @definition.method
+(abstract_method_signature) @definition.method

--- a/src/config/repoTypePresets.ts
+++ b/src/config/repoTypePresets.ts
@@ -8,6 +8,7 @@ import { ChunkingStrategy } from '../ingestion/chunker';
 export type DataSourceType =
   | 'general'
   | 'documentation'
+  | 'source-code'
   | 'github-actions-library'
   | 'cicd-workflows'
   | 'openapi-specs';
@@ -37,6 +38,16 @@ export const REPO_TYPE_PRESETS: Record<DataSourceType, RepoTypePreset> = {
     includePatterns: ['**/*.md', 'docs/**', 'wiki/**'],
     chunkingStrategy: 'markdown-heading',
     toolDescriptionTemplate: (o, r) => `Search ${o}/${r} documentation and standards`,
+  },
+  'source-code': {
+    id: 'source-code',
+    displayName: 'Source code (AST)',
+    wizardDescription:
+      'Code files — chunks split on functions, methods, and classes via Tree-sitter',
+    includePatterns: ['**/*.{ts,tsx,js,jsx,mjs,cjs,py,go,java,cs,rs,rb}'],
+    chunkingStrategy: 'ast-based',
+    toolDescriptionTemplate: (o, r) =>
+      `Search the ${o}/${r} codebase for functions, methods, and classes`,
   },
   'github-actions-library': {
     id: 'github-actions-library',

--- a/src/config/repoTypePresets.ts
+++ b/src/config/repoTypePresets.ts
@@ -1,9 +1,7 @@
 // Repo type preset registry.
-// Each type carries default include patterns, a chunking strategy, and a
-// tool description template. Type is selected once in the wizard and drives
-// defaults — users can override everything after selection.
-
-import { ChunkingStrategy } from '../ingestion/chunker';
+// Each type carries default include patterns and a tool description template.
+// Chunking strategy is chosen per-file inside the chunker (see
+// `Chunker.routeStrategy`); presets only decide which files get indexed.
 
 export type DataSourceType =
   | 'general'
@@ -18,7 +16,6 @@ export interface RepoTypePreset {
   displayName: string;
   wizardDescription: string;
   includePatterns: string[];
-  chunkingStrategy: ChunkingStrategy;
   toolDescriptionTemplate: (owner: string, repo: string) => string;
 }
 
@@ -26,35 +23,33 @@ export const REPO_TYPE_PRESETS: Record<DataSourceType, RepoTypePreset> = {
   general: {
     id: 'general',
     displayName: 'General codebase',
-    wizardDescription: 'Index all source files with default filters',
+    wizardDescription: 'Index all files with default filters',
     includePatterns: [],
-    chunkingStrategy: 'token-split',
     toolDescriptionTemplate: (o, r) => `Search the ${o}/${r} codebase`,
   },
   documentation: {
     id: 'documentation',
     displayName: 'Documentation / standards',
     wizardDescription: 'Markdown and docs files — chunks split on headings',
-    includePatterns: ['**/*.md', 'docs/**', 'wiki/**'],
-    chunkingStrategy: 'markdown-heading',
+    includePatterns: ['**/*.md', '**/*.mdx', 'docs/**', 'wiki/**'],
     toolDescriptionTemplate: (o, r) => `Search ${o}/${r} documentation and standards`,
   },
   'source-code': {
     id: 'source-code',
-    displayName: 'Source code (AST)',
+    displayName: 'Source code repository',
     wizardDescription:
-      'Code files — chunks split on functions, methods, and classes via Tree-sitter',
-    includePatterns: ['**/*.{ts,tsx,js,jsx,mjs,cjs,py,go,java,cs,rs,rb}'],
-    chunkingStrategy: 'ast-based',
+      'Code files plus inline docs — functions/classes chunked via Tree-sitter, markdown split on headings',
+    includePatterns: [
+      '**/*.{ts,tsx,js,jsx,mjs,cjs,py,go,java,cs,rs,rb,md,mdx}',
+    ],
     toolDescriptionTemplate: (o, r) =>
-      `Search the ${o}/${r} codebase for functions, methods, and classes`,
+      `Search the ${o}/${r} codebase for functions, methods, classes, and docs`,
   },
   'github-actions-library': {
     id: 'github-actions-library',
     displayName: 'GitHub Actions library',
     wizardDescription: 'action.yml / action.yaml files — one chunk per action',
-    includePatterns: ['**/action.yml', '**/action.yaml', 'README.md'],
-    chunkingStrategy: 'file-level',
+    includePatterns: ['**/action.yml', '**/action.yaml', '**/README.md'],
     toolDescriptionTemplate: (o, r) =>
       `Look up GitHub Actions in ${o}/${r} — available actions, inputs, outputs, and usage`,
   },
@@ -63,7 +58,6 @@ export const REPO_TYPE_PRESETS: Record<DataSourceType, RepoTypePreset> = {
     displayName: 'CI/CD workflows',
     wizardDescription: '.github/workflows/** — one chunk per workflow file',
     includePatterns: ['.github/workflows/**'],
-    chunkingStrategy: 'file-level',
     toolDescriptionTemplate: (o, r) =>
       `Search CI/CD workflow definitions in ${o}/${r} — pipelines, jobs, and triggers`,
   },
@@ -72,7 +66,6 @@ export const REPO_TYPE_PRESETS: Record<DataSourceType, RepoTypePreset> = {
     displayName: 'OpenAPI / specs',
     wizardDescription: 'YAML/JSON API spec files',
     includePatterns: ['**/*.yaml', '**/*.yml', '**/*.json', 'openapi/**', 'swagger/**'],
-    chunkingStrategy: 'token-split',
     toolDescriptionTemplate: (o, r) =>
       `Search API specs in ${o}/${r} — endpoints, operations, and schemas`,
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { ChunkStore } from './storage/chunkStore';
 import { EmbeddingStore } from './storage/embeddingStore';
 import { SyncStore } from './storage/syncStore';
 import { IngestionPipeline } from './ingestion/pipeline';
+import { ParserRegistry } from './ingestion/parserRegistry';
 import { Retriever } from './retrieval/retriever';
 import { ContextBuilder } from './retrieval/contextBuilder';
 import { ToolHandler } from './tools/toolHandler';
@@ -51,6 +52,13 @@ export function activate(context: vscode.ExtensionContext): void {
   // Delta sync
   const deltaSync = new DeltaSync(getToken);
 
+  // AST parser registry (lazy — WASM grammars load on first use)
+  const parserRegistry = new ParserRegistry({
+    extensionPath: context.extensionUri.fsPath,
+    queryDir: vscode.Uri.joinPath(context.extensionUri, 'dist', 'queries').fsPath,
+    logger,
+  });
+
   // Ingestion
   const pipeline = new IngestionPipeline(
     configManager,
@@ -61,6 +69,7 @@ export function activate(context: vscode.ExtensionContext): void {
     syncStore,
     logger,
     deltaSync,
+    parserRegistry,
   );
 
   // Surface pipeline errors as VS Code notifications

--- a/src/ingestion/astChunker.ts
+++ b/src/ingestion/astChunker.ts
@@ -1,0 +1,304 @@
+import type { Node } from 'web-tree-sitter';
+import type { Chunk } from './chunker';
+import { detectLanguage, lineCommentPrefix, SupportedLanguage } from './languageDetection';
+import type { ParserRegistry } from './parserRegistry';
+
+export type FallbackChunker = (content: string, filePath: string) => Chunk[];
+
+export interface AstChunkerLogger {
+  debug?(message: string): void;
+  warn?(message: string): void;
+}
+
+export interface AstChunkerDeps {
+  parserRegistry: ParserRegistry;
+  countTokens: (text: string) => number;
+  maxTokens: number;
+  fallback: FallbackChunker;
+  logger?: AstChunkerLogger;
+}
+
+type CaptureKind = 'function' | 'method' | 'class' | 'impl' | 'decorated';
+
+interface CapturedNode {
+  node: Node;
+  kind: CaptureKind;
+}
+
+// Node types that act as the "enclosing container" for method-style chunks.
+// When a function/method lives inside one of these, we prefix its chunk with
+// the container's name. Per-language to match each grammar.
+const CONTAINER_TYPES: Record<SupportedLanguage, ReadonlySet<string>> = {
+  typescript: new Set(['class_declaration', 'interface_declaration']),
+  tsx: new Set(['class_declaration', 'interface_declaration']),
+  javascript: new Set(['class_declaration']),
+  python: new Set(['class_definition']),
+  go: new Set([]), // Go methods use their receiver; handled separately.
+  java: new Set([
+    'class_declaration',
+    'interface_declaration',
+    'enum_declaration',
+    'record_declaration',
+  ]),
+  csharp: new Set([
+    'class_declaration',
+    'interface_declaration',
+    'struct_declaration',
+    'enum_declaration',
+    'record_declaration',
+  ]),
+  rust: new Set(['impl_item']),
+  ruby: new Set(['class', 'module']),
+};
+
+export async function chunkByAst(
+  content: string,
+  filePath: string,
+  deps: AstChunkerDeps,
+): Promise<Chunk[]> {
+  if (!content) return [];
+
+  const language = detectLanguage(filePath);
+  if (!language) return deps.fallback(content, filePath);
+
+  let loaded;
+  try {
+    loaded = await deps.parserRegistry.get(language);
+  } catch (err) {
+    deps.logger?.warn?.(
+      `ast: failed to load grammar for ${language} (${filePath}): ${errMsg(err)} \u2014 falling back`,
+    );
+    return deps.fallback(content, filePath);
+  }
+
+  let tree;
+  try {
+    tree = loaded.parser.parse(content);
+  } catch (err) {
+    deps.logger?.warn?.(`ast: parse error for ${filePath}: ${errMsg(err)} \u2014 falling back`);
+    return deps.fallback(content, filePath);
+  }
+  if (!tree) return deps.fallback(content, filePath);
+
+  let matches;
+  try {
+    matches = loaded.query.matches(tree.rootNode);
+  } catch (err) {
+    deps.logger?.warn?.(`ast: query error for ${filePath}: ${errMsg(err)} \u2014 falling back`);
+    tree.delete();
+    return deps.fallback(content, filePath);
+  }
+
+  const captured: CapturedNode[] = [];
+  for (const match of matches) {
+    for (const cap of match.captures) {
+      const kind = captureKind(cap.name);
+      if (!kind) continue;
+      captured.push({ node: cap.node, kind });
+    }
+  }
+
+  const emittable = selectEmittable(captured);
+
+  const chunks: Chunk[] = [];
+  for (const entry of emittable) {
+    chunks.push(...buildChunkForEntry(entry, language, deps));
+  }
+
+  tree.delete();
+
+  // Empty AST result (e.g. file with only imports/top-level statements, no
+  // function/class defs) — fall back so the file still contributes chunks.
+  if (chunks.length === 0) return deps.fallback(content, filePath);
+
+  chunks.sort((a, b) => a.startLine - b.startLine);
+  return chunks;
+}
+
+function captureKind(name: string): CaptureKind | null {
+  switch (name) {
+    case 'definition.function':
+      return 'function';
+    case 'definition.method':
+      return 'method';
+    case 'definition.class':
+      return 'class';
+    case 'definition.impl':
+      return 'impl';
+    case 'definition.decorated':
+      return 'decorated';
+    default:
+      return null;
+  }
+}
+
+// Determines which captures should produce chunks.
+//
+// Rules:
+//   - `impl` captures never emit on their own; they only exist so methods
+//     inside Rust impl blocks can look up their receiver type.
+//   - A `decorated` (Python) capture replaces the inner function/class
+//     capture it wraps — we emit the decorated span and drop the inner.
+//   - `function` / `method` / `decorated` captures emit unless strictly
+//     contained inside another emittable function/method/decorated capture
+//     (prevents nested helper functions from double-chunking).
+//   - `class` captures emit only if they contain no other emittable capture
+//     (otherwise the inner defs cover them).
+function selectEmittable(captured: CapturedNode[]): CapturedNode[] {
+  // Dedup the same node captured twice under different names.
+  const byId = new Map<number, CapturedNode>();
+  for (const cap of captured) {
+    const existing = byId.get(cap.node.id);
+    if (!existing || kindPriority(cap.kind) > kindPriority(existing.kind)) {
+      byId.set(cap.node.id, cap);
+    }
+  }
+  const all = [...byId.values()];
+
+  // Drop the inner function/class node when wrapped by a `decorated` node.
+  const decoratedIds = new Set(all.filter((c) => c.kind === 'decorated').map((c) => c.node.id));
+  const candidates = all.filter((c) => {
+    if (c.kind === 'impl') return false;
+    if (c.kind === 'function' || c.kind === 'class' || c.kind === 'method') {
+      const parent = c.node.parent;
+      if (parent && decoratedIds.has(parent.id)) return false;
+    }
+    return true;
+  });
+
+  const emitLikeFn = (c: CapturedNode): boolean =>
+    c.kind === 'function' || c.kind === 'method' || c.kind === 'decorated';
+
+  const result: CapturedNode[] = [];
+  for (const c of candidates) {
+    if (emitLikeFn(c)) {
+      // Drop if strictly contained in another function-like candidate.
+      const containedInFn = candidates.some(
+        (other) => other !== c && emitLikeFn(other) && strictlyContains(other.node, c.node),
+      );
+      if (containedInFn) continue;
+      result.push(c);
+    } else if (c.kind === 'class') {
+      const containsOther = candidates.some(
+        (other) => other !== c && other.kind !== 'impl' && strictlyContains(c.node, other.node),
+      );
+      if (containsOther) continue;
+      result.push(c);
+    }
+  }
+  return result;
+}
+
+function kindPriority(kind: CaptureKind): number {
+  // Higher wins when the same node is captured under multiple names.
+  // decorated > method > function > class > impl.
+  switch (kind) {
+    case 'decorated':
+      return 4;
+    case 'method':
+      return 3;
+    case 'function':
+      return 2;
+    case 'class':
+      return 1;
+    case 'impl':
+      return 0;
+  }
+}
+
+function strictlyContains(outer: Node, inner: Node): boolean {
+  if (outer.id === inner.id) return false;
+  return outer.startIndex <= inner.startIndex && outer.endIndex >= inner.endIndex;
+}
+
+function buildChunkForEntry(
+  entry: CapturedNode,
+  language: SupportedLanguage,
+  deps: AstChunkerDeps,
+): Chunk[] {
+  const { node } = entry;
+  const text = node.text;
+  const startLine = node.startPosition.row + 1;
+  const endLine = node.endPosition.row + 1;
+
+  const containerName = resolveContainerName(node, language);
+  const body =
+    containerName !== null
+      ? `${lineCommentPrefix(language)} Class: ${containerName}\n${text}`
+      : text;
+
+  const tokenCount = deps.countTokens(body);
+
+  if (tokenCount <= deps.maxTokens) {
+    return [{ content: body, startLine, endLine, tokenCount }];
+  }
+
+  // Oversized — delegate to the token-split fallback scoped to this node.
+  // Use the raw text (without the parent-class header) so line offsets stay
+  // aligned with the source; add the header only to the first sub-chunk.
+  const sub = deps.fallback(text, '');
+  if (sub.length === 0) {
+    return [{ content: body, startLine, endLine, tokenCount }];
+  }
+
+  return sub.map((c, i) => {
+    const content =
+      i === 0 && containerName !== null
+        ? `${lineCommentPrefix(language)} Class: ${containerName}\n${c.content}`
+        : c.content;
+    return {
+      content,
+      startLine: startLine + (c.startLine - 1),
+      endLine: startLine + (c.endLine - 1),
+      tokenCount: i === 0 && containerName !== null ? deps.countTokens(content) : c.tokenCount,
+    };
+  });
+}
+
+function resolveContainerName(node: Node, language: SupportedLanguage): string | null {
+  const containerTypes = CONTAINER_TYPES[language];
+
+  // Go methods get their receiver type as a prefix.
+  if (language === 'go' && node.type === 'method_declaration') {
+    const receiver = node.childForFieldName('receiver');
+    const receiverText = receiver?.text.trim();
+    if (receiverText) return receiverText;
+    return null;
+  }
+
+  let cur: Node | null = node.parent;
+  while (cur) {
+    if (containerTypes.has(cur.type)) {
+      const name = extractContainerName(cur, language);
+      if (name) return name;
+    }
+    cur = cur.parent;
+  }
+  return null;
+}
+
+function extractContainerName(container: Node, language: SupportedLanguage): string | null {
+  // Rust impl blocks have a `type` field (and optionally a `trait` field).
+  if (language === 'rust' && container.type === 'impl_item') {
+    const traitField = container.childForFieldName('trait');
+    const typeField = container.childForFieldName('type');
+    if (traitField && typeField) {
+      return `${traitField.text} for ${typeField.text}`;
+    }
+    return typeField?.text ?? null;
+  }
+
+  const nameField = container.childForFieldName('name');
+  if (nameField) return nameField.text;
+
+  // Fallback: first identifier-ish named child.
+  for (let i = 0; i < container.namedChildCount; i++) {
+    const child = container.namedChild(i);
+    if (child && /identifier/.test(child.type)) return child.text;
+  }
+  return null;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/ingestion/chunker.ts
+++ b/src/ingestion/chunker.ts
@@ -1,3 +1,6 @@
+import { chunkByAst, AstChunkerLogger } from './astChunker';
+import type { ParserRegistry } from './parserRegistry';
+
 export interface Chunk {
   content: string;
   startLine: number;
@@ -5,13 +8,19 @@ export interface Chunk {
   tokenCount: number;
 }
 
-export type ChunkingStrategy = 'token-split' | 'file-level' | 'markdown-heading';
+export type ChunkingStrategy = 'token-split' | 'file-level' | 'markdown-heading' | 'ast-based';
+
+export interface AstChunkerDepsOption {
+  parserRegistry: ParserRegistry;
+  logger?: AstChunkerLogger;
+}
 
 export interface ChunkerOptions {
   maxTokens: number;
   overlapTokens: number;
   countTokens: (text: string) => number;
   strategy: ChunkingStrategy;
+  astDeps?: AstChunkerDepsOption;
 }
 
 const DEFAULT_MAX_TOKENS = 512;
@@ -23,19 +32,37 @@ export class Chunker {
   private readonly overlapTokens: number;
   private readonly countTokens: (text: string) => number;
   private readonly strategy: ChunkingStrategy;
+  private readonly astDeps?: AstChunkerDepsOption;
 
   constructor(options?: Partial<ChunkerOptions>) {
     this.maxTokens = options?.maxTokens ?? DEFAULT_MAX_TOKENS;
     this.overlapTokens = options?.overlapTokens ?? DEFAULT_OVERLAP_TOKENS;
     this.countTokens = options?.countTokens ?? DEFAULT_COUNT_TOKENS;
     this.strategy = options?.strategy ?? 'token-split';
+    this.astDeps = options?.astDeps;
   }
 
-  chunkFile(content: string, filePath: string): Chunk[] {
+  async chunkFile(content: string, filePath: string): Promise<Chunk[]> {
     if (!content) return [];
+    if (this.strategy === 'ast-based') return this.chunkByAst(content, filePath);
     if (this.strategy === 'file-level') return this.chunkAsWhole(content);
     if (this.strategy === 'markdown-heading') return this.chunkByHeadings(content);
     return this.chunkByTokens(content, filePath);
+  }
+
+  private chunkByAst(content: string, filePath: string): Promise<Chunk[]> {
+    if (!this.astDeps) {
+      throw new Error(
+        "Chunker configured with strategy 'ast-based' but astDeps.parserRegistry was not provided",
+      );
+    }
+    return chunkByAst(content, filePath, {
+      parserRegistry: this.astDeps.parserRegistry,
+      countTokens: this.countTokens,
+      maxTokens: this.maxTokens,
+      fallback: (text, path) => this.chunkByTokens(text, path),
+      logger: this.astDeps.logger,
+    });
   }
 
   // One chunk spanning the entire file. Used for action.yml and workflow files

--- a/src/ingestion/chunker.ts
+++ b/src/ingestion/chunker.ts
@@ -1,4 +1,5 @@
 import { chunkByAst, AstChunkerLogger } from './astChunker';
+import { detectLanguage } from './languageDetection';
 import type { ParserRegistry } from './parserRegistry';
 
 export interface Chunk {
@@ -19,7 +20,11 @@ export interface ChunkerOptions {
   maxTokens: number;
   overlapTokens: number;
   countTokens: (text: string) => number;
-  strategy: ChunkingStrategy;
+  /**
+   * Force a single strategy for every file, bypassing per-file routing.
+   * Primarily for tests; production callers should rely on routing.
+   */
+  strategy?: ChunkingStrategy;
   astDeps?: AstChunkerDepsOption;
 }
 
@@ -31,22 +36,53 @@ export class Chunker {
   private readonly maxTokens: number;
   private readonly overlapTokens: number;
   private readonly countTokens: (text: string) => number;
-  private readonly strategy: ChunkingStrategy;
+  private readonly forcedStrategy?: ChunkingStrategy;
   private readonly astDeps?: AstChunkerDepsOption;
 
   constructor(options?: Partial<ChunkerOptions>) {
     this.maxTokens = options?.maxTokens ?? DEFAULT_MAX_TOKENS;
     this.overlapTokens = options?.overlapTokens ?? DEFAULT_OVERLAP_TOKENS;
     this.countTokens = options?.countTokens ?? DEFAULT_COUNT_TOKENS;
-    this.strategy = options?.strategy ?? 'token-split';
+    this.forcedStrategy = options?.strategy;
     this.astDeps = options?.astDeps;
   }
 
   async chunkFile(content: string, filePath: string): Promise<Chunk[]> {
     if (!content) return [];
-    if (this.strategy === 'ast-based') return this.chunkByAst(content, filePath);
-    if (this.strategy === 'file-level') return this.chunkAsWhole(content);
-    if (this.strategy === 'markdown-heading') return this.chunkByHeadings(content);
+    if (this.forcedStrategy) {
+      return this.dispatch(this.forcedStrategy, content, filePath);
+    }
+    let strategy = Chunker.routeStrategy(filePath);
+    if (strategy === 'ast-based' && !this.astDeps) {
+      // Parser registry wasn't wired in — degrade gracefully rather than throw.
+      strategy = 'token-split';
+    }
+    return this.dispatch(strategy, content, filePath);
+  }
+
+  /**
+   * Per-file routing table. Picks a chunking strategy based on path/extension.
+   * Callers may override via the `strategy` option but should only do so for tests.
+   */
+  static routeStrategy(filePath: string): ChunkingStrategy {
+    const lower = filePath.toLowerCase();
+    if (lower.endsWith('.md') || lower.endsWith('.mdx')) return 'markdown-heading';
+    if (
+      lower.includes('.github/workflows/') &&
+      (lower.endsWith('.yml') || lower.endsWith('.yaml'))
+    ) {
+      return 'file-level';
+    }
+    const base = lower.split('/').pop() ?? '';
+    if (base === 'action.yml' || base === 'action.yaml') return 'file-level';
+    if (detectLanguage(filePath) !== null) return 'ast-based';
+    return 'token-split';
+  }
+
+  private dispatch(strategy: ChunkingStrategy, content: string, filePath: string): Promise<Chunk[]> | Chunk[] {
+    if (strategy === 'ast-based') return this.chunkByAst(content, filePath);
+    if (strategy === 'file-level') return this.chunkAsWhole(content);
+    if (strategy === 'markdown-heading') return this.chunkByHeadings(content);
     return this.chunkByTokens(content, filePath);
   }
 

--- a/src/ingestion/languageDetection.ts
+++ b/src/ingestion/languageDetection.ts
@@ -1,0 +1,43 @@
+// Maps a file path extension to a tree-sitter language id used by
+// ParserRegistry. Returns null for anything not in the v1 supported set.
+
+export type SupportedLanguage =
+  | 'typescript'
+  | 'tsx'
+  | 'javascript'
+  | 'python'
+  | 'go'
+  | 'java'
+  | 'csharp'
+  | 'rust'
+  | 'ruby';
+
+const EXTENSION_TO_LANGUAGE: Record<string, SupportedLanguage> = {
+  ts: 'typescript',
+  mts: 'typescript',
+  cts: 'typescript',
+  tsx: 'tsx',
+  js: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  jsx: 'javascript',
+  py: 'python',
+  go: 'go',
+  java: 'java',
+  cs: 'csharp',
+  rs: 'rust',
+  rb: 'ruby',
+};
+
+export function detectLanguage(filePath: string): SupportedLanguage | null {
+  const dot = filePath.lastIndexOf('.');
+  if (dot < 0) return null;
+  const ext = filePath.slice(dot + 1).toLowerCase();
+  return EXTENSION_TO_LANGUAGE[ext] ?? null;
+}
+
+// Comment syntax used when prepending parent-class context to method chunks.
+export function lineCommentPrefix(language: SupportedLanguage): string {
+  if (language === 'python' || language === 'ruby') return '#';
+  return '//';
+}

--- a/src/ingestion/parserRegistry.ts
+++ b/src/ingestion/parserRegistry.ts
@@ -1,0 +1,94 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { Language, Parser, Query } from 'web-tree-sitter';
+import { SupportedLanguage } from './languageDetection';
+
+const WASM_FILENAME: Record<SupportedLanguage, string> = {
+  typescript: 'tree-sitter-typescript.wasm',
+  tsx: 'tree-sitter-tsx.wasm',
+  javascript: 'tree-sitter-javascript.wasm',
+  python: 'tree-sitter-python.wasm',
+  go: 'tree-sitter-go.wasm',
+  java: 'tree-sitter-java.wasm',
+  csharp: 'tree-sitter-c-sharp.wasm',
+  rust: 'tree-sitter-rust.wasm',
+  ruby: 'tree-sitter-ruby.wasm',
+};
+
+export interface LoadedLanguage {
+  parser: Parser;
+  query: Query;
+}
+
+export interface ParserRegistryLogger {
+  debug?(message: string): void;
+  warn?(message: string): void;
+}
+
+export interface ParserRegistryOptions {
+  extensionPath: string;
+  queryDir: string;
+  logger?: ParserRegistryLogger;
+}
+
+export class ParserRegistry {
+  private coreInit?: Promise<void>;
+  private readonly languages = new Map<SupportedLanguage, Promise<LoadedLanguage>>();
+  private readonly extensionPath: string;
+  private readonly queryDir: string;
+  private readonly logger?: ParserRegistryLogger;
+
+  constructor(options: ParserRegistryOptions) {
+    this.extensionPath = options.extensionPath;
+    this.queryDir = options.queryDir;
+    this.logger = options.logger;
+  }
+
+  async get(language: SupportedLanguage): Promise<LoadedLanguage> {
+    await this.ensureCore();
+    let entry = this.languages.get(language);
+    if (!entry) {
+      entry = this.load(language);
+      this.languages.set(language, entry);
+    }
+    return entry;
+  }
+
+  private ensureCore(): Promise<void> {
+    if (!this.coreInit) {
+      this.coreInit = (async () => {
+        const corePath = join(
+          this.extensionPath,
+          'node_modules',
+          'web-tree-sitter',
+          'web-tree-sitter.wasm',
+        );
+        const wasmBinary = await readFile(corePath);
+        await Parser.init({ wasmBinary });
+      })();
+    }
+    return this.coreInit;
+  }
+
+  private async load(language: SupportedLanguage): Promise<LoadedLanguage> {
+    const wasmPath = join(
+      this.extensionPath,
+      'node_modules',
+      '@vscode',
+      'tree-sitter-wasm',
+      'wasm',
+      WASM_FILENAME[language],
+    );
+    const wasmBytes = await readFile(wasmPath);
+    const grammar = await Language.load(new Uint8Array(wasmBytes));
+
+    const parser = new Parser();
+    parser.setLanguage(grammar);
+
+    const queryText = await readFile(join(this.queryDir, `${language}.scm`), 'utf8');
+    const query = new Query(grammar, queryText);
+
+    this.logger?.debug?.(`ast: loaded grammar ${language}`);
+    return { parser, query };
+  }
+}

--- a/src/ingestion/pipeline.ts
+++ b/src/ingestion/pipeline.ts
@@ -6,6 +6,7 @@ import { GitHubFetcher } from '../sources/github/githubFetcher';
 import { DeltaSync } from '../sources/sync/deltaSync';
 import { FileFilter } from './fileFilter';
 import { Chunker } from './chunker';
+import { ParserRegistry } from './parserRegistry';
 import { ChunkStore, ChunkRecord } from '../storage/chunkStore';
 import { EmbeddingStore } from '../storage/embeddingStore';
 import { SyncStore } from '../storage/syncStore';
@@ -48,6 +49,7 @@ export class IngestionPipeline {
     private readonly syncStore: SyncStore,
     private readonly logger: PipelineLogger,
     private readonly deltaSync?: DeltaSync,
+    private readonly parserRegistry?: ParserRegistry,
   ) {}
 
   onIndexingError(handler: (dataSourceId: string, message: string) => void): void {
@@ -172,11 +174,14 @@ export class IngestionPipeline {
           countTokens: provider.countTokens
             ? (text: string) => provider.countTokens!(text)
             : undefined,
+          astDeps: this.parserRegistry
+            ? { parserRegistry: this.parserRegistry, logger: this.logger }
+            : undefined,
         });
 
         const allChunks: ChunkRecord[] = [];
         for (const file of files) {
-          const chunks = chunker.chunkFile(file.content, file.path);
+          const chunks = await chunker.chunkFile(file.content, file.path);
           for (const chunk of chunks) {
             allChunks.push({
               id: crypto.randomUUID(),
@@ -248,12 +253,15 @@ export class IngestionPipeline {
       countTokens: provider.countTokens
         ? (text: string) => provider.countTokens!(text)
         : undefined,
+      astDeps: this.parserRegistry
+        ? { parserRegistry: this.parserRegistry, logger: this.logger }
+        : undefined,
     });
 
     // Chunk all files
     const allChunks: ChunkRecord[] = [];
     for (const file of files) {
-      const chunks = chunker.chunkFile(file.content, file.path);
+      const chunks = await chunker.chunkFile(file.content, file.path);
       for (const chunk of chunks) {
         allChunks.push({
           id: crypto.randomUUID(),

--- a/src/ingestion/pipeline.ts
+++ b/src/ingestion/pipeline.ts
@@ -1,6 +1,5 @@
 import * as crypto from 'crypto';
 import { DataSourceConfig } from '../config/configSchema';
-import { REPO_TYPE_PRESETS } from '../config/repoTypePresets';
 import { EmbeddingProvider } from '../embedding/embeddingProvider';
 import { GitHubFetcher } from '../sources/github/githubFetcher';
 import { DeltaSync } from '../sources/sync/deltaSync';
@@ -168,9 +167,7 @@ export class IngestionPipeline {
       if (toFetch.length > 0) {
         const files = await this.fetcher.fetchFiles(ds.owner, ds.repo, toFetch);
         const provider = await this.embeddingSource.getProvider();
-        const preset = REPO_TYPE_PRESETS[ds.type ?? 'general'];
         const chunker = new Chunker({
-          strategy: preset.chunkingStrategy,
           countTokens: provider.countTokens
             ? (text: string) => provider.countTokens!(text)
             : undefined,
@@ -247,9 +244,7 @@ export class IngestionPipeline {
 
     // Get embedding provider and build chunker
     const provider = await this.embeddingSource.getProvider();
-    const preset = REPO_TYPE_PRESETS[ds.type ?? 'general'];
     const chunker = new Chunker({
-      strategy: preset.chunkingStrategy,
       countTokens: provider.countTokens
         ? (text: string) => provider.countTokens!(text)
         : undefined,

--- a/test/fixtures/ast/sample.py
+++ b/test/fixtures/ast/sample.py
@@ -1,0 +1,15 @@
+def top_level(x):
+    return x * 2
+
+
+class Greeter:
+    def __init__(self, name):
+        self.name = name
+
+    def hello(self):
+        return f"hi {self.name}"
+
+
+@staticmethod
+def decorated_free():
+    return 42

--- a/test/fixtures/ast/sample.ts
+++ b/test/fixtures/ast/sample.ts
@@ -1,0 +1,21 @@
+// Module-level function
+function greet(name: string): string {
+  return `hello ${name}`;
+}
+
+class UserService {
+  private readonly store: Map<string, string>;
+
+  constructor() {
+    this.store = new Map();
+  }
+
+  async validateToken(token: string): Promise<boolean> {
+    if (!token) return false;
+    return this.store.has(token);
+  }
+
+  addUser(id: string, name: string): void {
+    this.store.set(id, name);
+  }
+}

--- a/test/unit/ingestion/astChunker.test.ts
+++ b/test/unit/ingestion/astChunker.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { chunkByAst } from '../../../src/ingestion/astChunker';
+import { ParserRegistry } from '../../../src/ingestion/parserRegistry';
+import type { Chunk } from '../../../src/ingestion/chunker';
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const FIXTURE_DIR = join(REPO_ROOT, 'test', 'fixtures', 'ast');
+
+const countTokens = (text: string): number => {
+  const trimmed = text.trim();
+  return trimmed.length === 0 ? 0 : trimmed.split(/\s+/).length;
+};
+
+// Minimal token-split fallback used by tests. Mirrors the real Chunker's
+// behavior closely enough to exercise the fallback code path without pulling
+// the whole Chunker class into scope.
+function tokenFallback(content: string, _filePath: string): Chunk[] {
+  const lines = content.split('\n');
+  if (lines.length === 0) return [];
+  const chunkSize = 2;
+  const chunks: Chunk[] = [];
+  for (let i = 0; i < lines.length; i += chunkSize) {
+    const slice = lines.slice(i, i + chunkSize);
+    chunks.push({
+      content: slice.join('\n'),
+      startLine: i + 1,
+      endLine: Math.min(i + slice.length, lines.length),
+      tokenCount: countTokens(slice.join('\n')),
+    });
+  }
+  return chunks;
+}
+
+let registry: ParserRegistry;
+
+beforeAll(() => {
+  registry = new ParserRegistry({
+    extensionPath: REPO_ROOT,
+    queryDir: join(REPO_ROOT, 'src', 'chunking', 'queries'),
+  });
+});
+
+describe('chunkByAst — TypeScript', () => {
+  it('produces one chunk per top-level function and each method, not the containing class', async () => {
+    const content = readFileSync(join(FIXTURE_DIR, 'sample.ts'), 'utf8');
+    const chunks = await chunkByAst(content, 'sample.ts', {
+      parserRegistry: registry,
+      countTokens,
+      maxTokens: 10_000,
+      fallback: tokenFallback,
+    });
+
+    // greet (1 function) + constructor + validateToken + addUser (3 methods) = 4 chunks.
+    // The UserService class itself should NOT be emitted because it contains methods.
+    expect(chunks).toHaveLength(4);
+
+    const greet = chunks.find((c) => c.content.includes('function greet'));
+    expect(greet).toBeDefined();
+    expect(greet!.content.startsWith('// Class:')).toBe(false);
+
+    const validate = chunks.find((c) => c.content.includes('validateToken'));
+    expect(validate).toBeDefined();
+    expect(validate!.content.startsWith('// Class: UserService\n')).toBe(true);
+
+    const ctor = chunks.find((c) => c.content.includes('constructor()'));
+    expect(ctor).toBeDefined();
+    expect(ctor!.content.startsWith('// Class: UserService\n')).toBe(true);
+
+    // Line numbers are 1-based and cover the method body.
+    expect(validate!.startLine).toBeLessThan(validate!.endLine);
+    expect(validate!.startLine).toBeGreaterThanOrEqual(1);
+  });
+
+  it('falls back to token-split when the file only has non-definition code', async () => {
+    const chunks = await chunkByAst(
+      "const x = 1;\nconst y = 2;\nconsole.log(x + y);\n",
+      'top.ts',
+      {
+        parserRegistry: registry,
+        countTokens,
+        maxTokens: 10_000,
+        fallback: tokenFallback,
+      },
+    );
+    // No functions/classes — fallback returns at least one chunk.
+    expect(chunks.length).toBeGreaterThan(0);
+    // None of the chunks should have a parent-class prefix (they came from the fallback).
+    for (const c of chunks) {
+      expect(c.content.startsWith('// Class:')).toBe(false);
+    }
+  });
+});
+
+describe('chunkByAst — Python', () => {
+  it('prefixes methods with "# Class: Name" and keeps module-level functions plain', async () => {
+    const content = readFileSync(join(FIXTURE_DIR, 'sample.py'), 'utf8');
+    const chunks = await chunkByAst(content, 'sample.py', {
+      parserRegistry: registry,
+      countTokens,
+      maxTokens: 10_000,
+      fallback: tokenFallback,
+    });
+
+    // top_level + __init__ + hello + decorated_free = 4 chunks; Greeter class itself suppressed.
+    expect(chunks).toHaveLength(4);
+
+    const topLevel = chunks.find((c) => c.content.includes('def top_level'));
+    expect(topLevel).toBeDefined();
+    expect(topLevel!.content.startsWith('# Class:')).toBe(false);
+
+    const hello = chunks.find((c) => c.content.includes('def hello'));
+    expect(hello).toBeDefined();
+    expect(hello!.content.startsWith('# Class: Greeter\n')).toBe(true);
+  });
+});
+
+describe('chunkByAst — fallback paths', () => {
+  it('falls back to token-split for unsupported extensions', async () => {
+    const content = 'local function foo()\n  return 1\nend\n';
+    let fallbackCalled = false;
+    const chunks = await chunkByAst(content, 'script.lua', {
+      parserRegistry: registry,
+      countTokens,
+      maxTokens: 100,
+      fallback: (c, p) => {
+        fallbackCalled = true;
+        return tokenFallback(c, p);
+      },
+    });
+    expect(fallbackCalled).toBe(true);
+    expect(chunks.length).toBeGreaterThan(0);
+  });
+
+  it('falls back when grammar loading fails', async () => {
+    const failingRegistry: ParserRegistry = {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async get() {
+        throw new Error('boom');
+      },
+    } as unknown as ParserRegistry;
+
+    let fallbackCalled = false;
+    const chunks = await chunkByAst('function x() {}\n', 'x.ts', {
+      parserRegistry: failingRegistry,
+      countTokens,
+      maxTokens: 100,
+      fallback: (c, p) => {
+        fallbackCalled = true;
+        return tokenFallback(c, p);
+      },
+    });
+    expect(fallbackCalled).toBe(true);
+    expect(chunks.length).toBeGreaterThan(0);
+  });
+
+  it('sub-splits an oversized function via the fallback with offset line numbers', async () => {
+    const fnLines = Array.from({ length: 40 }, (_, i) => `  const x${i} = ${i};`);
+    const content = ['', '', 'function big() {', ...fnLines, '}', ''].join('\n');
+    // Function starts at line 3 in the source file.
+
+    const chunks = await chunkByAst(content, 'big.ts', {
+      parserRegistry: registry,
+      countTokens,
+      maxTokens: 5, // forces oversized handling
+      fallback: tokenFallback,
+    });
+
+    // The big function should have been split into multiple sub-chunks.
+    expect(chunks.length).toBeGreaterThan(1);
+    // Line numbers should be source-relative: the first sub-chunk starts at
+    // the function's start line (3), not at 1.
+    expect(chunks[0].startLine).toBe(3);
+    // And later sub-chunks advance past line 3.
+    expect(chunks[chunks.length - 1].endLine).toBeGreaterThan(3);
+  });
+});

--- a/test/unit/ingestion/chunker.test.ts
+++ b/test/unit/ingestion/chunker.test.ts
@@ -8,15 +8,15 @@ const wordCount = (text: string): number => {
 };
 
 describe('Chunker', () => {
-  it('returns empty array for empty content', () => {
+  it('returns empty array for empty content', async () => {
     const chunker = new Chunker();
-    expect(chunker.chunkFile('', 'test.ts')).toEqual([]);
+    expect(await chunker.chunkFile('', 'test.ts')).toEqual([]);
   });
 
-  it('returns a single chunk for small files', () => {
+  it('returns a single chunk for small files', async () => {
     const chunker = new Chunker({ maxTokens: 100, overlapTokens: 10 });
     const content = 'line one\nline two\nline three';
-    const chunks = chunker.chunkFile(content, 'small.ts');
+    const chunks = await chunker.chunkFile(content, 'small.ts');
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0].content).toBe(content);
@@ -24,7 +24,7 @@ describe('Chunker', () => {
     expect(chunks[0].endLine).toBe(3);
   });
 
-  it('splits large files into multiple chunks', () => {
+  it('splits large files into multiple chunks', async () => {
     // 10 tokens per chunk, word-based counting
     const chunker = new Chunker({
       maxTokens: 10,
@@ -35,7 +35,7 @@ describe('Chunker', () => {
     // 5 words per line × 6 lines = 30 words → should produce 3 chunks
     const lines = Array.from({ length: 6 }, (_, i) => `word1 word2 word3 word4 line${i}`);
     const content = lines.join('\n');
-    const chunks = chunker.chunkFile(content, 'big.ts');
+    const chunks = await chunker.chunkFile(content, 'big.ts');
 
     expect(chunks.length).toBeGreaterThanOrEqual(3);
     // All content should be covered
@@ -45,7 +45,7 @@ describe('Chunker', () => {
     }
   });
 
-  it('produces overlapping chunks', () => {
+  it('produces overlapping chunks', async () => {
     const chunker = new Chunker({
       maxTokens: 10,
       overlapTokens: 5,
@@ -60,7 +60,7 @@ describe('Chunker', () => {
       'papa quebec romeo sierra tango',
     ];
     const content = lines.join('\n');
-    const chunks = chunker.chunkFile(content, 'overlap.ts');
+    const chunks = await chunker.chunkFile(content, 'overlap.ts');
 
     // With overlap, later chunks should start before the previous chunk ended
     if (chunks.length >= 2) {
@@ -68,16 +68,16 @@ describe('Chunker', () => {
     }
   });
 
-  it('uses 1-based line numbers', () => {
+  it('uses 1-based line numbers', async () => {
     const chunker = new Chunker({ maxTokens: 1000, overlapTokens: 0 });
     const content = 'first\nsecond\nthird';
-    const chunks = chunker.chunkFile(content, 'test.ts');
+    const chunks = await chunker.chunkFile(content, 'test.ts');
 
     expect(chunks[0].startLine).toBe(1);
     expect(chunks[0].endLine).toBe(3);
   });
 
-  it('reports token count per chunk', () => {
+  it('reports token count per chunk', async () => {
     const chunker = new Chunker({
       maxTokens: 10,
       overlapTokens: 0,
@@ -85,7 +85,7 @@ describe('Chunker', () => {
     });
 
     const content = 'one two three four five\nsix seven eight nine ten\neleven twelve';
-    const chunks = chunker.chunkFile(content, 'test.ts');
+    const chunks = await chunker.chunkFile(content, 'test.ts');
 
     for (const chunk of chunks) {
       expect(chunk.tokenCount).toBeGreaterThan(0);
@@ -93,7 +93,7 @@ describe('Chunker', () => {
     }
   });
 
-  it('never produces empty chunks', () => {
+  it('never produces empty chunks', async () => {
     const chunker = new Chunker({
       maxTokens: 5,
       overlapTokens: 2,
@@ -102,14 +102,14 @@ describe('Chunker', () => {
 
     const lines = Array.from({ length: 20 }, (_, i) => `word${i} another${i}`);
     const content = lines.join('\n');
-    const chunks = chunker.chunkFile(content, 'test.ts');
+    const chunks = await chunker.chunkFile(content, 'test.ts');
 
     for (const chunk of chunks) {
       expect(chunk.content.length).toBeGreaterThan(0);
     }
   });
 
-  it('guarantees forward progress even with very small maxTokens', () => {
+  it('guarantees forward progress even with very small maxTokens', async () => {
     const chunker = new Chunker({
       maxTokens: 1,
       overlapTokens: 0,
@@ -117,7 +117,7 @@ describe('Chunker', () => {
     });
 
     const content = 'hello world\nfoo bar';
-    const chunks = chunker.chunkFile(content, 'test.ts');
+    const chunks = await chunker.chunkFile(content, 'test.ts');
 
     // Should not infinite loop, and should cover all lines
     expect(chunks.length).toBeGreaterThanOrEqual(2);
@@ -125,30 +125,30 @@ describe('Chunker', () => {
     expect(lastChunk.endLine).toBe(2);
   });
 
-  it('handles single-line files', () => {
+  it('handles single-line files', async () => {
     const chunker = new Chunker({ maxTokens: 100, overlapTokens: 10 });
-    const chunks = chunker.chunkFile('single line content', 'one.ts');
+    const chunks = await chunker.chunkFile('single line content', 'one.ts');
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0].startLine).toBe(1);
     expect(chunks[0].endLine).toBe(1);
   });
 
-  it('uses default char/4 tokenizer when no countTokens provided', () => {
+  it('uses default char/4 tokenizer when no countTokens provided', async () => {
     const chunker = new Chunker({ maxTokens: 10, overlapTokens: 0 });
     // 40 chars = ~10 tokens with char/4 estimate
     const content = 'a'.repeat(40) + '\n' + 'b'.repeat(40);
-    const chunks = chunker.chunkFile(content, 'test.ts');
+    const chunks = await chunker.chunkFile(content, 'test.ts');
 
     expect(chunks.length).toBeGreaterThanOrEqual(2);
   });
 });
 
 describe('Chunker — file-level strategy', () => {
-  it('returns a single chunk for the entire file', () => {
+  it('returns a single chunk for the entire file', async () => {
     const chunker = new Chunker({ strategy: 'file-level', maxTokens: 10 });
     const content = 'line one\nline two\nline three\nline four\nline five';
-    const chunks = chunker.chunkFile(content, 'action.yml');
+    const chunks = await chunker.chunkFile(content, 'action.yml');
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0].content).toBe(content);
@@ -156,25 +156,25 @@ describe('Chunker — file-level strategy', () => {
     expect(chunks[0].endLine).toBe(5);
   });
 
-  it('returns empty array for empty content', () => {
+  it('returns empty array for empty content', async () => {
     const chunker = new Chunker({ strategy: 'file-level' });
-    expect(chunker.chunkFile('', 'empty.yml')).toEqual([]);
+    expect(await chunker.chunkFile('', 'empty.yml')).toEqual([]);
   });
 
-  it('reports correct token count for a single-chunk file', () => {
+  it('reports correct token count for a single-chunk file', async () => {
     const chunker = new Chunker({
       strategy: 'file-level',
       countTokens: wordCount,
     });
     const content = 'alpha bravo charlie\ndelta echo foxtrot';
-    const chunks = chunker.chunkFile(content, 'wf.yml');
+    const chunks = await chunker.chunkFile(content, 'wf.yml');
 
     expect(chunks[0].tokenCount).toBe(6);
   });
 });
 
 describe('Chunker — markdown-heading strategy', () => {
-  it('splits content on # headings', () => {
+  it('splits content on # headings', async () => {
     const chunker = new Chunker({ strategy: 'markdown-heading', maxTokens: 1000 });
     const content = [
       '# Introduction',
@@ -184,17 +184,17 @@ describe('Chunker — markdown-heading strategy', () => {
       'Usage details here.',
     ].join('\n');
 
-    const chunks = chunker.chunkFile(content, 'README.md');
+    const chunks = await chunker.chunkFile(content, 'README.md');
 
     expect(chunks).toHaveLength(2);
     expect(chunks[0].content).toContain('# Introduction');
     expect(chunks[1].content).toContain('# Usage');
   });
 
-  it('uses 1-based line numbers relative to the original file', () => {
+  it('uses 1-based line numbers relative to the original file', async () => {
     const chunker = new Chunker({ strategy: 'markdown-heading', maxTokens: 1000 });
     const content = '# First\nfirst body\n# Second\nsecond body';
-    const chunks = chunker.chunkFile(content, 'doc.md');
+    const chunks = await chunker.chunkFile(content, 'doc.md');
 
     expect(chunks[0].startLine).toBe(1);
     expect(chunks[0].endLine).toBe(2);
@@ -202,7 +202,7 @@ describe('Chunker — markdown-heading strategy', () => {
     expect(chunks[1].endLine).toBe(4);
   });
 
-  it('sub-chunks oversized sections with token-split and preserves line offsets', () => {
+  it('sub-chunks oversized sections with token-split and preserves line offsets', async () => {
     const chunker = new Chunker({
       strategy: 'markdown-heading',
       maxTokens: 3,
@@ -217,7 +217,7 @@ describe('Chunker — markdown-heading strategy', () => {
       'seven eight nine',
     ].join('\n');
 
-    const chunks = chunker.chunkFile(content, 'big.md');
+    const chunks = await chunker.chunkFile(content, 'big.md');
 
     expect(chunks.length).toBeGreaterThan(1);
     // All sub-chunk startLines should be >= 1 (file-relative)
@@ -230,17 +230,24 @@ describe('Chunker — markdown-heading strategy', () => {
     expect(lastChunk.endLine).toBe(4);
   });
 
-  it('handles files with no headings as a single section', () => {
+  it('handles files with no headings as a single section', async () => {
     const chunker = new Chunker({ strategy: 'markdown-heading', maxTokens: 1000 });
     const content = 'No headings here.\nJust plain text.\n';
-    const chunks = chunker.chunkFile(content, 'plain.md');
+    const chunks = await chunker.chunkFile(content, 'plain.md');
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0].startLine).toBe(1);
   });
 
-  it('returns empty array for empty content', () => {
+  it('returns empty array for empty content', async () => {
     const chunker = new Chunker({ strategy: 'markdown-heading' });
-    expect(chunker.chunkFile('', 'empty.md')).toEqual([]);
+    expect(await chunker.chunkFile('', 'empty.md')).toEqual([]);
+  });
+});
+
+describe('Chunker — ast-based strategy', () => {
+  it('throws a clear error when ast-based is selected without astDeps', async () => {
+    const chunker = new Chunker({ strategy: 'ast-based' });
+    await expect(chunker.chunkFile('function x() {}', 'x.ts')).rejects.toThrow(/parserRegistry/);
   });
 });

--- a/test/unit/ingestion/chunker.test.ts
+++ b/test/unit/ingestion/chunker.test.ts
@@ -10,13 +10,13 @@ const wordCount = (text: string): number => {
 describe('Chunker', () => {
   it('returns empty array for empty content', async () => {
     const chunker = new Chunker();
-    expect(await chunker.chunkFile('', 'test.ts')).toEqual([]);
+    expect(await chunker.chunkFile('', 'test.txt')).toEqual([]);
   });
 
   it('returns a single chunk for small files', async () => {
     const chunker = new Chunker({ maxTokens: 100, overlapTokens: 10 });
     const content = 'line one\nline two\nline three';
-    const chunks = await chunker.chunkFile(content, 'small.ts');
+    const chunks = await chunker.chunkFile(content, 'small.txt');
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0].content).toBe(content);
@@ -25,7 +25,6 @@ describe('Chunker', () => {
   });
 
   it('splits large files into multiple chunks', async () => {
-    // 10 tokens per chunk, word-based counting
     const chunker = new Chunker({
       maxTokens: 10,
       overlapTokens: 0,
@@ -35,10 +34,9 @@ describe('Chunker', () => {
     // 5 words per line × 6 lines = 30 words → should produce 3 chunks
     const lines = Array.from({ length: 6 }, (_, i) => `word1 word2 word3 word4 line${i}`);
     const content = lines.join('\n');
-    const chunks = await chunker.chunkFile(content, 'big.ts');
+    const chunks = await chunker.chunkFile(content, 'big.txt');
 
     expect(chunks.length).toBeGreaterThanOrEqual(3);
-    // All content should be covered
     for (const chunk of chunks) {
       expect(chunk.startLine).toBeGreaterThanOrEqual(1);
       expect(chunk.endLine).toBeGreaterThanOrEqual(chunk.startLine);
@@ -52,7 +50,6 @@ describe('Chunker', () => {
       countTokens: wordCount,
     });
 
-    // 5 words per line × 4 lines = 20 words
     const lines = [
       'alpha bravo charlie delta echo',
       'foxtrot golf hotel india juliet',
@@ -60,9 +57,8 @@ describe('Chunker', () => {
       'papa quebec romeo sierra tango',
     ];
     const content = lines.join('\n');
-    const chunks = await chunker.chunkFile(content, 'overlap.ts');
+    const chunks = await chunker.chunkFile(content, 'overlap.txt');
 
-    // With overlap, later chunks should start before the previous chunk ended
     if (chunks.length >= 2) {
       expect(chunks[1].startLine).toBeLessThan(chunks[0].endLine + 1);
     }
@@ -71,7 +67,7 @@ describe('Chunker', () => {
   it('uses 1-based line numbers', async () => {
     const chunker = new Chunker({ maxTokens: 1000, overlapTokens: 0 });
     const content = 'first\nsecond\nthird';
-    const chunks = await chunker.chunkFile(content, 'test.ts');
+    const chunks = await chunker.chunkFile(content, 'test.txt');
 
     expect(chunks[0].startLine).toBe(1);
     expect(chunks[0].endLine).toBe(3);
@@ -85,11 +81,11 @@ describe('Chunker', () => {
     });
 
     const content = 'one two three four five\nsix seven eight nine ten\neleven twelve';
-    const chunks = await chunker.chunkFile(content, 'test.ts');
+    const chunks = await chunker.chunkFile(content, 'test.txt');
 
     for (const chunk of chunks) {
       expect(chunk.tokenCount).toBeGreaterThan(0);
-      expect(chunk.tokenCount).toBeLessThanOrEqual(12); // small margin
+      expect(chunk.tokenCount).toBeLessThanOrEqual(12);
     }
   });
 
@@ -102,7 +98,7 @@ describe('Chunker', () => {
 
     const lines = Array.from({ length: 20 }, (_, i) => `word${i} another${i}`);
     const content = lines.join('\n');
-    const chunks = await chunker.chunkFile(content, 'test.ts');
+    const chunks = await chunker.chunkFile(content, 'test.txt');
 
     for (const chunk of chunks) {
       expect(chunk.content.length).toBeGreaterThan(0);
@@ -117,9 +113,8 @@ describe('Chunker', () => {
     });
 
     const content = 'hello world\nfoo bar';
-    const chunks = await chunker.chunkFile(content, 'test.ts');
+    const chunks = await chunker.chunkFile(content, 'test.txt');
 
-    // Should not infinite loop, and should cover all lines
     expect(chunks.length).toBeGreaterThanOrEqual(2);
     const lastChunk = chunks[chunks.length - 1];
     expect(lastChunk.endLine).toBe(2);
@@ -127,7 +122,7 @@ describe('Chunker', () => {
 
   it('handles single-line files', async () => {
     const chunker = new Chunker({ maxTokens: 100, overlapTokens: 10 });
-    const chunks = await chunker.chunkFile('single line content', 'one.ts');
+    const chunks = await chunker.chunkFile('single line content', 'one.txt');
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0].startLine).toBe(1);
@@ -136,15 +131,99 @@ describe('Chunker', () => {
 
   it('uses default char/4 tokenizer when no countTokens provided', async () => {
     const chunker = new Chunker({ maxTokens: 10, overlapTokens: 0 });
-    // 40 chars = ~10 tokens with char/4 estimate
     const content = 'a'.repeat(40) + '\n' + 'b'.repeat(40);
-    const chunks = await chunker.chunkFile(content, 'test.ts');
+    const chunks = await chunker.chunkFile(content, 'test.txt');
 
     expect(chunks.length).toBeGreaterThanOrEqual(2);
   });
 });
 
-describe('Chunker — file-level strategy', () => {
+describe('Chunker.routeStrategy', () => {
+  it('routes markdown files to markdown-heading', () => {
+    expect(Chunker.routeStrategy('README.md')).toBe('markdown-heading');
+    expect(Chunker.routeStrategy('docs/guide.MDX')).toBe('markdown-heading');
+    expect(Chunker.routeStrategy('nested/path/NOTES.md')).toBe('markdown-heading');
+  });
+
+  it('routes AST-supported source files to ast-based', () => {
+    expect(Chunker.routeStrategy('src/foo.ts')).toBe('ast-based');
+    expect(Chunker.routeStrategy('app.tsx')).toBe('ast-based');
+    expect(Chunker.routeStrategy('lib/util.py')).toBe('ast-based');
+    expect(Chunker.routeStrategy('main.go')).toBe('ast-based');
+    expect(Chunker.routeStrategy('Example.java')).toBe('ast-based');
+    expect(Chunker.routeStrategy('Service.cs')).toBe('ast-based');
+    expect(Chunker.routeStrategy('mod.rs')).toBe('ast-based');
+    expect(Chunker.routeStrategy('app.rb')).toBe('ast-based');
+  });
+
+  it('routes GitHub Actions workflow YAML to file-level', () => {
+    expect(Chunker.routeStrategy('.github/workflows/ci.yml')).toBe('file-level');
+    expect(Chunker.routeStrategy('.github/workflows/release.yaml')).toBe('file-level');
+  });
+
+  it('routes action.yml/action.yaml to file-level', () => {
+    expect(Chunker.routeStrategy('action.yml')).toBe('file-level');
+    expect(Chunker.routeStrategy('actions/checkout/action.yaml')).toBe('file-level');
+  });
+
+  it('falls back to token-split for unknown file types', () => {
+    expect(Chunker.routeStrategy('config.json')).toBe('token-split');
+    expect(Chunker.routeStrategy('spec.yaml')).toBe('token-split');
+    expect(Chunker.routeStrategy('notes.txt')).toBe('token-split');
+    expect(Chunker.routeStrategy('LICENSE')).toBe('token-split');
+  });
+});
+
+describe('Chunker — per-file routing (default)', () => {
+  it('uses markdown-heading behavior for .md files', async () => {
+    const chunker = new Chunker({ maxTokens: 1000 });
+    const content = '# Alpha\nbody a\n# Beta\nbody b';
+    const chunks = await chunker.chunkFile(content, 'README.md');
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].content).toContain('# Alpha');
+    expect(chunks[1].content).toContain('# Beta');
+  });
+
+  it('uses file-level behavior for workflow YAML', async () => {
+    const chunker = new Chunker({ maxTokens: 5, countTokens: wordCount });
+    const content = 'name: CI\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest';
+    const chunks = await chunker.chunkFile(content, '.github/workflows/ci.yml');
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].content).toBe(content);
+  });
+
+  it('uses file-level behavior for action.yml', async () => {
+    const chunker = new Chunker({ maxTokens: 5, countTokens: wordCount });
+    const content = 'name: my-action\ndescription: Does a thing\nruns:\n  using: node20';
+    const chunks = await chunker.chunkFile(content, 'path/to/action.yml');
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].content).toBe(content);
+  });
+
+  it('falls back to token-split for ast files when astDeps is missing', async () => {
+    const chunker = new Chunker({ maxTokens: 10, countTokens: wordCount });
+    const content = 'function a() { return 1 }\nfunction b() { return 2 }\nfunction c() { return 3 }';
+    const chunks = await chunker.chunkFile(content, 'foo.ts');
+
+    // Should not throw — degrades to token-split when parser registry absent.
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('uses token-split for generic text files', async () => {
+    const chunker = new Chunker({ maxTokens: 100, overlapTokens: 0 });
+    const content = 'just plain text\nwith a few lines\nof content';
+    const chunks = await chunker.chunkFile(content, 'notes.txt');
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].startLine).toBe(1);
+    expect(chunks[0].endLine).toBe(3);
+  });
+});
+
+describe('Chunker — file-level strategy (forced)', () => {
   it('returns a single chunk for the entire file', async () => {
     const chunker = new Chunker({ strategy: 'file-level', maxTokens: 10 });
     const content = 'line one\nline two\nline three\nline four\nline five';
@@ -173,7 +252,7 @@ describe('Chunker — file-level strategy', () => {
   });
 });
 
-describe('Chunker — markdown-heading strategy', () => {
+describe('Chunker — markdown-heading strategy (forced)', () => {
   it('splits content on # headings', async () => {
     const chunker = new Chunker({ strategy: 'markdown-heading', maxTokens: 1000 });
     const content = [
@@ -209,7 +288,6 @@ describe('Chunker — markdown-heading strategy', () => {
       overlapTokens: 0,
       countTokens: wordCount,
     });
-    // Section has 9 words → exceeds maxTokens 3 → sub-chunked into 3 pieces
     const content = [
       '# Big Section',
       'one two three',
@@ -220,12 +298,10 @@ describe('Chunker — markdown-heading strategy', () => {
     const chunks = await chunker.chunkFile(content, 'big.md');
 
     expect(chunks.length).toBeGreaterThan(1);
-    // All sub-chunk startLines should be >= 1 (file-relative)
     for (const chunk of chunks) {
       expect(chunk.startLine).toBeGreaterThanOrEqual(1);
       expect(chunk.endLine).toBeGreaterThanOrEqual(chunk.startLine);
     }
-    // Last chunk should end at line 4
     const lastChunk = chunks[chunks.length - 1];
     expect(lastChunk.endLine).toBe(4);
   });
@@ -245,8 +321,8 @@ describe('Chunker — markdown-heading strategy', () => {
   });
 });
 
-describe('Chunker — ast-based strategy', () => {
-  it('throws a clear error when ast-based is selected without astDeps', async () => {
+describe('Chunker — ast-based strategy (forced)', () => {
+  it('throws a clear error when ast-based is forced without astDeps', async () => {
     const chunker = new Chunker({ strategy: 'ast-based' });
     await expect(chunker.chunkFile('function x() {}', 'x.ts')).rejects.toThrow(/parserRegistry/);
   });

--- a/test/unit/ingestion/languageDetection.test.ts
+++ b/test/unit/ingestion/languageDetection.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { detectLanguage, lineCommentPrefix } from '../../../src/ingestion/languageDetection';
+
+describe('detectLanguage', () => {
+  const cases: Array<[string, ReturnType<typeof detectLanguage>]> = [
+    ['foo.ts', 'typescript'],
+    ['foo.mts', 'typescript'],
+    ['foo.cts', 'typescript'],
+    ['foo.tsx', 'tsx'],
+    ['foo.js', 'javascript'],
+    ['foo.mjs', 'javascript'],
+    ['foo.cjs', 'javascript'],
+    ['foo.jsx', 'javascript'],
+    ['foo.py', 'python'],
+    ['foo.go', 'go'],
+    ['Foo.java', 'java'],
+    ['Foo.cs', 'csharp'],
+    ['foo.rs', 'rust'],
+    ['foo.rb', 'ruby'],
+    ['src/deep/nested/path.ts', 'typescript'],
+    ['UPPER.PY', 'python'],
+    // Unsupported / unknown
+    ['foo.lua', null],
+    ['foo.md', null],
+    ['foo.yaml', null],
+    ['Makefile', null],
+    ['no-extension', null],
+    ['', null],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`maps "${input}" -> ${expected}`, () => {
+      expect(detectLanguage(input)).toBe(expected);
+    });
+  }
+});
+
+describe('lineCommentPrefix', () => {
+  it('uses # for Python and Ruby', () => {
+    expect(lineCommentPrefix('python')).toBe('#');
+    expect(lineCommentPrefix('ruby')).toBe('#');
+  });
+
+  it('uses // for curly-brace languages', () => {
+    expect(lineCommentPrefix('typescript')).toBe('//');
+    expect(lineCommentPrefix('javascript')).toBe('//');
+    expect(lineCommentPrefix('tsx')).toBe('//');
+    expect(lineCommentPrefix('go')).toBe('//');
+    expect(lineCommentPrefix('java')).toBe('//');
+    expect(lineCommentPrefix('csharp')).toBe('//');
+    expect(lineCommentPrefix('rust')).toBe('//');
+  });
+});

--- a/test/unit/ui/addRepoWizard.test.ts
+++ b/test/unit/ui/addRepoWizard.test.ts
@@ -138,7 +138,7 @@ describe('AddRepoWizard', () => {
     expect(dataSourceManager.add).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'github-actions-library',
-        includePatterns: ['**/action.yml', '**/action.yaml', 'README.md'],
+        includePatterns: ['**/action.yml', '**/action.yaml', '**/README.md'],
       }),
     );
   });


### PR DESCRIPTION
Adds a fourth chunking strategy, 'ast-based', that splits source code at
semantic boundaries (functions, methods, classes) instead of arbitrary
character/token boundaries. Each chunk is a complete unit; method chunks
are prepended with their enclosing class/receiver name so embeddings
carry context.

Supported languages: TypeScript, TSX, JavaScript/JSX, Python, Go, Java,
C#, Rust, Ruby. Unsupported languages (or parse failures) fall back to
token-split.

Implementation uses web-tree-sitter + @vscode/tree-sitter-wasm (no
native bindings, which crash in the VS Code extension host). WASM
grammars and .scm queries load lazily per language on first use and
are cached for the process lifetime. Queries live in
src/chunking/queries/ and ship to dist/queries/ via a small
build-time copy step.

Enabled via a new 'source-code' repo type preset; existing presets
are unchanged. Chunker.chunkFile is now async to accommodate the
lazy WASM loads.