### PR TITLE
Add indexing progress, cost estimates, add button, and edit settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "commands": [
       {
         "command": "yoink.addRepository",
-        "title": "Yoink: Add Repository"
+        "title": "Yoink: Add Repository",
+        "icon": "$(add)"
       },
       {
         "command": "yoink.removeRepository",
@@ -73,6 +74,11 @@
         "icon": "$(edit)"
       },
       {
+        "command": "yoink.editDataSourceFromTree",
+        "title": "Edit",
+        "icon": "$(edit)"
+      },
+      {
         "command": "yoink.exportConfig",
         "title": "Yoink: Export Config to Workspace"
       },
@@ -86,7 +92,19 @@
       }
     ],
     "menus": {
+      "view/title": [
+        {
+          "command": "yoink.addRepository",
+          "when": "view == yoink.dataSources",
+          "group": "navigation"
+        }
+      ],
       "view/item/context": [
+        {
+          "command": "yoink.editDataSourceFromTree",
+          "when": "view == yoink.dataSources && viewItem == dataSource",
+          "group": "inline"
+        },
         {
           "command": "yoink.syncDataSourceFromTree",
           "when": "view == yoink.dataSources && viewItem == dataSource",

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -7,6 +7,7 @@ export interface DataSourceConfig {
   repo: string;
   branch: string;
   type: DataSourceType;
+  description?: string;
   includePatterns: string[];
   excludePatterns: string[];
   syncSchedule: 'manual' | 'onStartup' | 'daily';
@@ -60,6 +61,7 @@ export interface ShareableDataSource {
   repo: string;
   branch: string;
   type?: DataSourceType;
+  description?: string;
   includePatterns: string[];
   excludePatterns: string[];
   syncSchedule: 'manual' | 'onStartup' | 'daily';

--- a/src/embedding/pricing.ts
+++ b/src/embedding/pricing.ts
@@ -1,0 +1,17 @@
+const PRICING_TABLE: Record<string, number> = {
+  'text-embedding-3-small': 0.02 / 1_000_000,
+  'text-embedding-3-large': 0.13 / 1_000_000,
+  'text-embedding-ada-002': 0.10 / 1_000_000,
+};
+
+export function getPricingForModel(modelId: string): { costPerToken: number } {
+  return { costPerToken: PRICING_TABLE[modelId] ?? 0 };
+}
+
+export function formatCost(totalTokens: number, costPerToken: number): string {
+  if (costPerToken === 0) return '';
+  const cost = totalTokens * costPerToken;
+  if (cost === 0) return '$0.00';
+  if (cost < 0.01) return '<$0.01';
+  return `$${cost.toFixed(2)}`;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { EmbeddingStore } from './storage/embeddingStore';
 import { SyncStore } from './storage/syncStore';
 import { IngestionPipeline } from './ingestion/pipeline';
 import { ParserRegistry } from './ingestion/parserRegistry';
+import { ProgressTracker } from './ingestion/progressTracker';
 import { Retriever } from './retrieval/retriever';
 import { ContextBuilder } from './retrieval/contextBuilder';
 import { ToolHandler } from './tools/toolHandler';
@@ -60,6 +61,9 @@ export function activate(context: vscode.ExtensionContext): void {
     logger,
   });
 
+  // Progress tracking (in-memory, drives sidebar live updates)
+  const progressTracker = new ProgressTracker();
+
   // Ingestion
   const pipeline = new IngestionPipeline(
     configManager,
@@ -71,6 +75,7 @@ export function activate(context: vscode.ExtensionContext): void {
     logger,
     deltaSync,
     parserRegistry,
+    progressTracker,
   );
 
   // Surface pipeline errors as VS Code notifications
@@ -100,7 +105,7 @@ export function activate(context: vscode.ExtensionContext): void {
   toolManager.registerAll();
 
   // Sidebar
-  const dataSourceTreeProvider = new DataSourceTreeProvider(configManager, chunkStore);
+  const dataSourceTreeProvider = new DataSourceTreeProvider(configManager, chunkStore, progressTracker);
   const toolTreeProvider = new ToolTreeProvider(configManager);
   const embeddingTreeProvider = new EmbeddingTreeProvider(providerRegistry, context.secrets);
   vscode.window.registerTreeDataProvider('yoink.dataSources', dataSourceTreeProvider);
@@ -140,6 +145,7 @@ export function activate(context: vscode.ExtensionContext): void {
     toolManager,
     scheduler,
     embeddingTreeProvider,
+    progressTracker,
     logger,
   );
 

--- a/src/ingestion/pipeline.ts
+++ b/src/ingestion/pipeline.ts
@@ -6,6 +6,7 @@ import { DeltaSync } from '../sources/sync/deltaSync';
 import { FileFilter } from './fileFilter';
 import { Chunker } from './chunker';
 import { ParserRegistry } from './parserRegistry';
+import { ProgressTracker } from './progressTracker';
 import { ChunkStore, ChunkRecord } from '../storage/chunkStore';
 import { EmbeddingStore } from '../storage/embeddingStore';
 import { SyncStore } from '../storage/syncStore';
@@ -49,6 +50,7 @@ export class IngestionPipeline {
     private readonly logger: PipelineLogger,
     private readonly deltaSync?: DeltaSync,
     private readonly parserRegistry?: ParserRegistry,
+    private readonly progressTracker?: ProgressTracker,
   ) {}
 
   onIndexingError(handler: (dataSourceId: string, message: string) => void): void {
@@ -119,6 +121,7 @@ export class IngestionPipeline {
         status: 'error',
         errorMessage: message,
       });
+      this.progressTracker?.complete(dataSourceId);
       try { this.syncStore.failSync(syncId, message); } catch { /* best-effort */ }
       this.logger.error(`Indexing failed for ${ds.owner}/${ds.repo}: ${message}`);
       for (const handler of this._onIndexingError) {
@@ -165,6 +168,7 @@ export class IngestionPipeline {
       // Fetch and chunk added + modified files
       const toFetch = [...addedFiltered, ...modifiedFiltered];
       if (toFetch.length > 0) {
+        this.progressTracker?.start(dataSourceId, toFetch.length);
         const files = await this.fetcher.fetchFiles(ds.owner, ds.repo, toFetch);
         const provider = await this.embeddingSource.getProvider();
         const chunker = new Chunker({
@@ -180,8 +184,9 @@ export class IngestionPipeline {
         const allChunks: ChunkRecord[] = [];
         for (const file of files) {
           const chunks = await chunker.chunkFile(file.content, file.path);
+          const fileChunks: ChunkRecord[] = [];
           for (const chunk of chunks) {
-            allChunks.push({
+            fileChunks.push({
               id: crypto.randomUUID(),
               dataSourceId,
               filePath: file.path,
@@ -191,6 +196,9 @@ export class IngestionPipeline {
               tokenCount: chunk.tokenCount,
             });
           }
+          allChunks.push(...fileChunks);
+          const fileTokens = fileChunks.reduce((sum, c) => sum + c.tokenCount, 0);
+          this.progressTracker?.fileProcessed(dataSourceId, fileChunks.length, fileTokens);
         }
 
         this.chunkStore.insertMany(allChunks);
@@ -202,6 +210,7 @@ export class IngestionPipeline {
         lastSyncedAt: new Date().toISOString(),
         lastSyncCommitSha: commitSha,
       });
+      this.progressTracker?.complete(dataSourceId);
       this.syncStore.completeSync(syncId, toFetch.length, this.chunkStore.countByDataSource(dataSourceId));
       this.logger.info(`Delta sync complete for ${ds.owner}/${ds.repo}`);
       return true;
@@ -234,6 +243,7 @@ export class IngestionPipeline {
 
     this.logger.info(`Fetching ${filteredEntries.length} files`);
     progress?.report(`Fetching ${filteredEntries.length} files...`);
+    this.progressTracker?.start(dataSourceId, filteredEntries.length);
 
     // Clear existing data for this source (full re-index)
     const oldChunkIds = this.chunkStore.getChunkIdsByDataSource(dataSourceId);
@@ -260,8 +270,9 @@ export class IngestionPipeline {
     const allChunks: ChunkRecord[] = [];
     for (const file of files) {
       const chunks = await chunker.chunkFile(file.content, file.path);
+      const fileChunks: ChunkRecord[] = [];
       for (const chunk of chunks) {
-        allChunks.push({
+        fileChunks.push({
           id: crypto.randomUUID(),
           dataSourceId,
           filePath: file.path,
@@ -271,6 +282,9 @@ export class IngestionPipeline {
           tokenCount: chunk.tokenCount,
         });
       }
+      allChunks.push(...fileChunks);
+      const fileTokens = fileChunks.reduce((sum, c) => sum + c.tokenCount, 0);
+      this.progressTracker?.fileProcessed(dataSourceId, fileChunks.length, fileTokens);
     }
 
     // Store chunks
@@ -286,6 +300,7 @@ export class IngestionPipeline {
       lastSyncedAt: new Date().toISOString(),
       lastSyncCommitSha: commitSha,
     });
+    this.progressTracker?.complete(dataSourceId);
     this.syncStore.completeSync(syncId, files.length, allChunks.length);
     this.logger.info(`Indexed ${allChunks.length} chunks from ${files.length} files`);
   }

--- a/src/ingestion/progressTracker.ts
+++ b/src/ingestion/progressTracker.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+
+export interface IndexingProgress {
+  dataSourceId: string;
+  totalFiles: number;
+  processedFiles: number;
+  totalTokens: number;
+}
+
+export class ProgressTracker implements vscode.Disposable {
+  private readonly state = new Map<string, IndexingProgress>();
+  private readonly _onDidChange = new vscode.EventEmitter<string>();
+  readonly onDidChange = this._onDidChange.event;
+
+  start(dataSourceId: string, totalFiles: number): void {
+    this.state.set(dataSourceId, {
+      dataSourceId,
+      totalFiles,
+      processedFiles: 0,
+      totalTokens: 0,
+    });
+    this._onDidChange.fire(dataSourceId);
+  }
+
+  fileProcessed(dataSourceId: string, chunkCount: number, tokenCount: number): void {
+    const s = this.state.get(dataSourceId);
+    if (!s) return;
+    s.processedFiles += 1;
+    s.totalTokens += tokenCount;
+    this._onDidChange.fire(dataSourceId);
+  }
+
+  complete(dataSourceId: string): void {
+    this.state.delete(dataSourceId);
+    this._onDidChange.fire(dataSourceId);
+  }
+
+  get(dataSourceId: string): IndexingProgress | undefined {
+    return this.state.get(dataSourceId);
+  }
+
+  dispose(): void {
+    this._onDidChange.dispose();
+  }
+}

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -114,16 +114,90 @@ export function registerCommands(
       }
     }),
 
-    vscode.commands.registerCommand('yoink.editToolFromTree', async (item: ToolTreeItem) => {
-      const newDescription = await vscode.window.showInputBox({
-        prompt: 'Tool description',
-        value: item.tool.description,
+    vscode.commands.registerCommand('yoink.editDataSourceFromTree', async (item: DataSourceTreeItem) => {
+      const ds = item.dataSource;
+      const repoLabel = `${ds.owner}/${ds.repo}`;
+
+      const description = await vscode.window.showInputBox({
+        title: `Edit ${repoLabel} (1/3)`,
+        prompt: 'Description (optional)',
+        value: ds.description ?? '',
         ignoreFocusOut: true,
       });
-      if (newDescription !== undefined) {
-        configManager.updateTool(item.tool.id, { description: newDescription });
-        vscode.window.showInformationMessage(`Updated tool "${item.tool.name}".`);
+      if (description === undefined) return;
+
+      const scheduleItems = [
+        { label: 'Manual', description: 'Only sync when manually triggered', value: 'manual' as const },
+        { label: 'On Startup', description: 'Sync when VS Code starts', value: 'onStartup' as const },
+        { label: 'Daily', description: 'Sync once per day', value: 'daily' as const },
+      ];
+      const currentIdx = scheduleItems.findIndex((s) => s.value === ds.syncSchedule);
+      const schedulePick = await vscode.window.showQuickPick(scheduleItems, {
+        title: `Edit ${repoLabel} (2/3)`,
+        placeHolder: 'Sync schedule',
+        activeItems: currentIdx >= 0 ? [scheduleItems[currentIdx]] : [],
+        ignoreFocusOut: true,
+      });
+      if (!schedulePick) return;
+
+      const includeInput = await vscode.window.showInputBox({
+        title: `Edit ${repoLabel} (3/3)`,
+        prompt: 'Include patterns (comma-separated globs, leave empty for all files)',
+        value: ds.includePatterns.join(', '),
+        ignoreFocusOut: true,
+      });
+      if (includeInput === undefined) return;
+
+      const includePatterns = includeInput
+        ? includeInput.split(',').map((p) => p.trim()).filter(Boolean)
+        : [];
+
+      configManager.updateDataSource(ds.id, {
+        description: description || undefined,
+        syncSchedule: schedulePick.value,
+        includePatterns,
+      });
+      vscode.window.showInformationMessage(`Updated ${repoLabel}.`);
+    }),
+
+    vscode.commands.registerCommand('yoink.editToolFromTree', async (item: ToolTreeItem) => {
+      const tool = item.tool;
+
+      const description = await vscode.window.showInputBox({
+        title: `Edit tool "${tool.name}" (1/2)`,
+        prompt: 'Tool description',
+        value: tool.description,
+        ignoreFocusOut: true,
+      });
+      if (description === undefined) return;
+
+      const allDataSources = configManager.getDataSources();
+      if (allDataSources.length === 0) {
+        configManager.updateTool(tool.id, { description });
+        vscode.window.showInformationMessage(`Updated tool "${tool.name}".`);
+        return;
       }
+
+      const dataSourceItems = allDataSources.map((ds) => ({
+        label: `${ds.owner}/${ds.repo}`,
+        description: ds.branch,
+        id: ds.id,
+        picked: tool.dataSourceIds.includes(ds.id),
+      }));
+
+      const picked = await vscode.window.showQuickPick(dataSourceItems, {
+        title: `Edit tool "${tool.name}" (2/2)`,
+        placeHolder: 'Select data sources for this tool',
+        canPickMany: true,
+        ignoreFocusOut: true,
+      });
+      if (picked === undefined) return;
+
+      configManager.updateTool(tool.id, {
+        description,
+        dataSourceIds: picked.map((p) => p.id),
+      });
+      vscode.window.showInformationMessage(`Updated tool "${tool.name}".`);
     }),
 
     vscode.commands.registerCommand('yoink.editTool', async () => {

--- a/src/ui/sidebar/sidebarProvider.ts
+++ b/src/ui/sidebar/sidebarProvider.ts
@@ -11,6 +11,7 @@ import {
 import { EmbeddingProviderRegistry } from '../../embedding/registry';
 import { SETTING_KEYS } from '../../config/settingsSchema';
 import { ChunkStore } from '../../storage/chunkStore';
+import { ProgressTracker } from '../../ingestion/progressTracker';
 
 export class DataSourceTreeProvider
   implements vscode.TreeDataProvider<SidebarTreeItem>
@@ -21,8 +22,10 @@ export class DataSourceTreeProvider
   constructor(
     private readonly configManager: ConfigManager,
     private readonly chunkStore: ChunkStore,
+    private readonly progressTracker: ProgressTracker,
   ) {
     configManager.onDidChange(() => this.refresh());
+    progressTracker.onDidChange(() => this.refresh());
   }
 
   refresh(): void {
@@ -36,7 +39,7 @@ export class DataSourceTreeProvider
   getChildren(element?: SidebarTreeItem): SidebarTreeItem[] {
     if (!element) {
       return this.configManager.getDataSources().map(
-        (ds) => new DataSourceTreeItem(ds),
+        (ds) => new DataSourceTreeItem(ds, this.progressTracker.get(ds.id)),
       );
     }
 
@@ -44,9 +47,12 @@ export class DataSourceTreeProvider
       const dsId = element.dataSource.id;
       const stats = this.chunkStore.getDataSourceStats(dsId);
       const fileStats = this.chunkStore.getFileStats(dsId);
+      const model = vscode.workspace.getConfiguration().get<string>(
+        SETTING_KEYS.OPENAI_MODEL, 'text-embedding-3-small',
+      );
 
       return [
-        new DataSourceInfoItem(stats, element.dataSource),
+        new DataSourceInfoItem(stats, element.dataSource, model),
         ...fileStats.map((fs) => new DataSourceFileItem(fs)),
       ];
     }

--- a/src/ui/sidebar/sidebarTreeItems.ts
+++ b/src/ui/sidebar/sidebarTreeItems.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import { DataSourceConfig, ToolConfig } from '../../config/configSchema';
 import { ConfigManager } from '../../config/configManager';
 import { DataSourceStats, FileStats } from '../../storage/chunkStore';
+import { IndexingProgress } from '../../ingestion/progressTracker';
+import { getPricingForModel, formatCost } from '../../embedding/pricing';
 
 export type SidebarTreeItem =
   | DataSourceTreeItem
@@ -17,8 +19,15 @@ const STATUS_ICONS: Record<string, string> = {
   error: '$(error)',
 };
 
+function formatNumber(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
 export class DataSourceTreeItem extends vscode.TreeItem {
-  constructor(public readonly dataSource: DataSourceConfig) {
+  constructor(
+    public readonly dataSource: DataSourceConfig,
+    private readonly progress?: IndexingProgress,
+  ) {
     super(
       `${dataSource.owner}/${dataSource.repo}`,
       dataSource.status === 'ready'
@@ -26,8 +35,15 @@ export class DataSourceTreeItem extends vscode.TreeItem {
         : vscode.TreeItemCollapsibleState.None,
     );
 
-    const icon = STATUS_ICONS[dataSource.status] || '$(question)';
-    this.description = `${icon} ${dataSource.branch}`;
+    if (dataSource.status === 'indexing' && progress) {
+      const filesText = `${progress.processedFiles}/${progress.totalFiles} files`;
+      const tokensText = `${formatNumber(progress.totalTokens)} tokens`;
+      this.description = `$(sync~spin) ${filesText} · ${tokensText}`;
+    } else {
+      const icon = STATUS_ICONS[dataSource.status] || '$(question)';
+      this.description = `${icon} ${dataSource.branch}`;
+    }
+
     this.tooltip = this.buildTooltip();
     this.contextValue = 'dataSource';
 
@@ -43,8 +59,11 @@ export class DataSourceTreeItem extends vscode.TreeItem {
   private buildTooltip(): string {
     const lines = [
       `${this.dataSource.owner}/${this.dataSource.repo}@${this.dataSource.branch}`,
-      `Status: ${this.dataSource.status}`,
     ];
+    if (this.dataSource.description) {
+      lines.push(this.dataSource.description);
+    }
+    lines.push(`Status: ${this.dataSource.status}`);
     if (this.dataSource.lastSyncedAt) {
       lines.push(`Last synced: ${this.dataSource.lastSyncedAt}`);
     }
@@ -55,12 +74,8 @@ export class DataSourceTreeItem extends vscode.TreeItem {
   }
 }
 
-function formatNumber(n: number): string {
-  return n.toLocaleString('en-US');
-}
-
 export class DataSourceInfoItem extends vscode.TreeItem {
-  constructor(stats: DataSourceStats, dataSource: DataSourceConfig) {
+  constructor(stats: DataSourceStats, dataSource: DataSourceConfig, embeddingModel?: string) {
     const label = `${formatNumber(stats.fileCount)} files · ${formatNumber(stats.chunkCount)} chunks · ${formatNumber(stats.totalTokens)} tokens`;
     super(label, vscode.TreeItemCollapsibleState.None);
 
@@ -73,6 +88,13 @@ export class DataSourceInfoItem extends vscode.TreeItem {
       `Chunks: ${formatNumber(stats.chunkCount)}`,
       `Tokens: ${formatNumber(stats.totalTokens)}`,
     ];
+    if (embeddingModel) {
+      const { costPerToken } = getPricingForModel(embeddingModel);
+      const costStr = formatCost(stats.totalTokens, costPerToken);
+      if (costStr) {
+        lines.push(`Est. indexing cost: ${costStr}`);
+      }
+    }
     if (dataSource.lastSyncedAt) {
       lines.push(`Last synced: ${dataSource.lastSyncedAt}`);
     }

--- a/test/unit/ui/sidebar/sidebar.test.ts
+++ b/test/unit/ui/sidebar/sidebar.test.ts
@@ -29,6 +29,9 @@ vi.mock('vscode', () => ({
     fire(data: any) { this.listeners.forEach((l) => l(data)); }
     dispose() {}
   },
+  workspace: {
+    getConfiguration: () => ({ get: (_key: string, defaultValue?: any) => defaultValue }),
+  },
 }));
 
 import {
@@ -215,6 +218,13 @@ describe('DataSourceTreeProvider', () => {
     } as any;
   }
 
+  function makeProgressTracker() {
+    return {
+      get: vi.fn().mockReturnValue(undefined),
+      onDidChange: (cb: () => void) => { return { dispose: vi.fn() }; },
+    } as any;
+  }
+
   it('returns data source tree items from config at root', () => {
     const changeCallbacks: Array<() => void> = [];
     const configManager = {
@@ -222,7 +232,7 @@ describe('DataSourceTreeProvider', () => {
       onDidChange: (cb: () => void) => { changeCallbacks.push(cb); return { dispose: vi.fn() }; },
     } as any;
 
-    const provider = new DataSourceTreeProvider(configManager, makeChunkStore());
+    const provider = new DataSourceTreeProvider(configManager, makeChunkStore(), makeProgressTracker());
     const children = provider.getChildren();
 
     expect(children).toHaveLength(2);
@@ -244,7 +254,7 @@ describe('DataSourceTreeProvider', () => {
       ],
     );
 
-    const provider = new DataSourceTreeProvider(configManager, chunkStore);
+    const provider = new DataSourceTreeProvider(configManager, chunkStore, makeProgressTracker());
     const dsItem = new DataSourceTreeItem(makeDs());
     const children = provider.getChildren(dsItem);
 
@@ -262,7 +272,7 @@ describe('DataSourceTreeProvider', () => {
       onDidChange: () => ({ dispose: vi.fn() }),
     } as any;
 
-    const provider = new DataSourceTreeProvider(configManager, makeChunkStore());
+    const provider = new DataSourceTreeProvider(configManager, makeChunkStore(), makeProgressTracker());
     const dsItem = new DataSourceTreeItem(makeDs({ status: 'indexing' }));
     const children = provider.getChildren(dsItem);
 
@@ -276,7 +286,7 @@ describe('DataSourceTreeProvider', () => {
       onDidChange: (cb: () => void) => { changeCallbacks.push(cb); return { dispose: vi.fn() }; },
     } as any;
 
-    const provider = new DataSourceTreeProvider(configManager, makeChunkStore());
+    const provider = new DataSourceTreeProvider(configManager, makeChunkStore(), makeProgressTracker());
     const listener = vi.fn();
     provider.onDidChangeTreeData(listener);
 


### PR DESCRIPTION
- Show live file-count progress (15/100 files · 43,200 tokens) in the
  Data Sources sidebar item description while indexing; driven by new
  ProgressTracker that fires VS Code EventEmitter updates per file
- Show estimated embedding API cost in the DataSourceInfoItem tooltip
  after indexing completes, based on per-model pricing table
- Add $(add) button to the Data Sources panel header that launches the
  add repository wizard directly from the sidebar
- Add yoink.editDataSourceFromTree command (3-step: description, sync
  schedule, include patterns) and register it as an inline $(edit) icon
  on each data source tree item; adds optional description field to
  DataSourceConfig
- Extend yoink.editToolFromTree to a 2-step flow: edit description then
  pick associated data sources via multi-select QuickPick

https://claude.ai/code/session_01GyuMzUUqiXMDVn8RxkhMod