### PR TITLE
Install agents to .copilot/agents instead of .claude/agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
       },
       {
         "command": "yoink.installAgents",
-        "title": "Yoink: Install Claude Agents"
+        "title": "Yoink: Install Copilot Agents"
       }
     ],
     "menus": {

--- a/src/agents/agentInstaller.ts
+++ b/src/agents/agentInstaller.ts
@@ -5,7 +5,7 @@ export class AgentInstaller {
 
   async install(workspaceUri: vscode.Uri): Promise<number> {
     const sourceDir = vscode.Uri.joinPath(this.extensionUri, 'agents');
-    const targetDir = vscode.Uri.joinPath(workspaceUri, '.claude', 'agents');
+    const targetDir = vscode.Uri.joinPath(workspaceUri, '.copilot', 'agents');
 
     await vscode.workspace.fs.createDirectory(targetDir);
 
@@ -27,7 +27,7 @@ export class AgentInstaller {
   }
 
   async isInstalled(workspaceUri: vscode.Uri): Promise<boolean> {
-    const markerUri = vscode.Uri.joinPath(workspaceUri, '.claude', 'agents', 'yoink-agent.md');
+    const markerUri = vscode.Uri.joinPath(workspaceUri, '.copilot', 'agents', 'yoink-agent.md');
     try {
       await vscode.workspace.fs.stat(markerUri);
       return true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,14 +152,14 @@ export function activate(context: vscode.ExtensionContext): void {
   // Detect workspace config and prompt import
   workspaceConfigManager.detectAndPrompt();
 
-  // Prompt to install Claude Code agent files on first activation
+  // Prompt to install Copilot agent files on first activation
   const primaryFolder = vscode.workspace.workspaceFolders?.[0];
   if (primaryFolder) {
     agentInstaller.isInstalled(primaryFolder.uri).then((installed) => {
       if (!installed) {
         vscode.window
           .showInformationMessage(
-            'Yoink: Install agent files for Claude Code in this workspace?',
+            'Yoink: Install agent files for Copilot in this workspace?',
             'Install',
             'Later',
           )


### PR DESCRIPTION
Copilot picks up agent files from .copilot/agents/, not .claude/agents/.
Also updates the command title and activation prompt to reference Copilot.

https://claude.ai/code/session_01Wm92R6vcq1GAZ2HkzkscNe