### PR TITLE
Enhance Copilot agent installation and repository browsing

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,22 +152,14 @@ export function activate(context: vscode.ExtensionContext): void {
   // Detect workspace config and prompt import
   workspaceConfigManager.detectAndPrompt();
 
-  // Prompt to install Copilot agent files on first activation
+  // Silently install Copilot agent files on first activation
   const primaryFolder = vscode.workspace.workspaceFolders?.[0];
   if (primaryFolder) {
     agentInstaller.isInstalled(primaryFolder.uri).then((installed) => {
       if (!installed) {
-        vscode.window
-          .showInformationMessage(
-            'Yoink: Install agent files for Copilot in this workspace?',
-            'Install',
-            'Later',
-          )
-          .then((choice) => {
-            if (choice === 'Install') {
-              vscode.commands.executeCommand('yoink.installAgents');
-            }
-          });
+        agentInstaller.install(primaryFolder.uri).catch((err) => {
+          logger.error(`Failed to install agent files: ${err}`);
+        });
       }
     });
   }

--- a/src/sources/github/repoBrowser.ts
+++ b/src/sources/github/repoBrowser.ts
@@ -26,6 +26,18 @@ export class RepoBrowser {
     return (await res.json() as RepoListItem[]).map(mapRepoItem);
   }
 
+  async listAllUserRepos(): Promise<RepoSearchResult[]> {
+    const all: RepoSearchResult[] = [];
+    let page = 1;
+    while (true) {
+      const batch = await this.listUserRepos(page, 100);
+      all.push(...batch);
+      if (batch.length < 100) break;
+      page++;
+    }
+    return all;
+  }
+
   async listStarredRepos(page: number = 1, perPage: number = 30): Promise<RepoSearchResult[]> {
     const token = await this.getToken();
     const res = await fetch(

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -243,7 +243,7 @@ export function registerCommands(
       try {
         const count = await agentInstaller.install(folder.uri);
         vscode.window.showInformationMessage(
-          `Yoink: Installed ${count} agent file${count !== 1 ? 's' : ''} to .claude/agents/`,
+          `Yoink: Installed ${count} agent file${count !== 1 ? 's' : ''} to .copilot/agents/`,
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/ui/wizard/addRepoWizard.ts
+++ b/src/ui/wizard/addRepoWizard.ts
@@ -168,8 +168,11 @@ export class AddRepoWizard {
       return isRepoUrlResult(result) ? result : undefined;
     }
 
-    // Browse repos
-    const repos = await this.browser.listUserRepos();
+    // Browse repos — fetch all pages so large orgs (600+ repos) are fully searchable
+    const repos = await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Notification, title: 'Loading repositories…' },
+      () => this.browser.listAllUserRepos(),
+    );
     const picked = await vscode.window.showQuickPick(
       repos.map((r) => ({
         label: r.fullName,


### PR DESCRIPTION
- Silently install Copilot agent files on first activation instead of prompting the user.
- Update agent installation path to .copilot/agents.
- Implement a method to fetch all user repositories, supporting large organizations with many repos.