### PR TITLE
fix: resolve CI failures (lint, schema v3, wizard mock, pipeline tarball)

### DIFF
--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -122,7 +122,7 @@ function migrate(db: Database.Database, dimensions: number): void {
       INSERT INTO chunks_fts (chunk_id, data_source_id, file_path, content)
       SELECT id, data_source_id, file_path, content FROM chunks;
     `);
-    setSchemaVersion(db, 3);
+    setSchemaVersion(db, SCHEMA_VERSION);
   }
 }
 

--- a/test/unit/ingestion/pipeline.test.ts
+++ b/test/unit/ingestion/pipeline.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { gzipSync } from 'node:zlib';
+import { pack as tarPack } from 'tar-stream';
 import Database from 'better-sqlite3';
 import { openDatabase } from '../../../src/storage/database';
 import { ChunkStore } from '../../../src/storage/chunkStore';
@@ -16,6 +18,15 @@ import { DataSourceConfig } from '../../../src/config/configSchema';
 import { EmbeddingProvider } from '../../../src/embedding/embeddingProvider';
 
 // --- Test fixtures ---
+
+async function buildTarGz(entries: Array<{ name: string; content: string }>): Promise<Buffer> {
+  const p = tarPack();
+  for (const e of entries) p.entry({ name: e.name }, e.content);
+  p.finalize();
+  const chunks: Buffer[] = [];
+  for await (const chunk of p) chunks.push(chunk as Buffer);
+  return gzipSync(Buffer.concat(chunks));
+}
 
 const TEST_DIMS = 4;
 
@@ -131,6 +142,9 @@ describe('IngestionPipeline', () => {
   }
 
   function mockGitHubApi(files: Array<{ path: string; content: string }>) {
+    // Build the tarball once, synchronously keyed on files content
+    let tarballBuf: Buffer | null = null;
+
     globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
       const urlStr = String(url);
       const headers = new Headers({
@@ -141,7 +155,7 @@ describe('IngestionPipeline', () => {
       // Branch SHA
       if (urlStr.includes('/branches/')) {
         return {
-          ok: true, status: 200, headers,
+          ok: true, status: 200, statusText: 'OK', headers,
           json: async () => ({ commit: { sha: 'abc123' } }),
         };
       }
@@ -149,7 +163,7 @@ describe('IngestionPipeline', () => {
       // Tree
       if (urlStr.includes('/git/trees/')) {
         return {
-          ok: true, status: 200, headers,
+          ok: true, status: 200, statusText: 'OK', headers,
           json: async () => ({
             tree: files.map((f, i) => ({
               path: f.path,
@@ -162,17 +176,26 @@ describe('IngestionPipeline', () => {
         };
       }
 
-      // Blob
-      if (urlStr.includes('/git/blobs/')) {
-        const sha = urlStr.split('/blobs/')[1];
-        const idx = parseInt(sha.replace('blob-sha-', ''), 10);
+      // Tarball — pipeline fetches the full repo as a tar.gz
+      if (urlStr.includes('/tarball/')) {
+        if (!tarballBuf) {
+          tarballBuf = await buildTarGz(
+            files.map((f) => ({ name: `test-repo-abc123/${f.path}`, content: f.content })),
+          );
+        }
+        const buf = tarballBuf;
         return {
-          ok: true, status: 200, headers,
-          text: async () => files[idx].content,
+          ok: true, status: 200, statusText: 'OK', headers,
+          body: new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(buf));
+              controller.close();
+            },
+          }),
         };
       }
 
-      return { ok: false, status: 404, headers, text: async () => 'not found' };
+      return { ok: false, status: 404, statusText: 'Not Found', headers, text: async () => 'not found' };
     });
   }
 

--- a/test/unit/ingestion/pipeline.test.ts
+++ b/test/unit/ingestion/pipeline.test.ts
@@ -176,7 +176,7 @@ describe('IngestionPipeline', () => {
         };
       }
 
-      // Tarball — pipeline fetches the full repo as a tar.gz
+      // Tarball — full ingest fetches the whole repo as a tar.gz
       if (urlStr.includes('/tarball/')) {
         if (!tarballBuf) {
           tarballBuf = await buildTarGz(
@@ -192,6 +192,17 @@ describe('IngestionPipeline', () => {
               controller.close();
             },
           }),
+        };
+      }
+
+      // Blob — delta sync fetches individual files via the blob API
+      if (urlStr.includes('/git/blobs/')) {
+        const sha = urlStr.split('/blobs/')[1];
+        const idx = parseInt(sha.replace('blob-sha-', ''), 10);
+        const content = isNaN(idx) ? '' : (files[idx]?.content ?? '');
+        return {
+          ok: true, status: 200, statusText: 'OK', headers,
+          text: async () => content,
         };
       }
 

--- a/test/unit/storage/database.test.ts
+++ b/test/unit/storage/database.test.ts
@@ -51,7 +51,7 @@ describe('openDatabase', () => {
       .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
       .get() as { value: string };
 
-    expect(row.value).toBe('2');
+    expect(row.value).toBe('3');
     db.close();
   });
 
@@ -83,7 +83,7 @@ describe('openDatabase', () => {
     const row = db2
       .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
       .get() as { value: string };
-    expect(row.value).toBe('2');
+    expect(row.value).toBe('3');
     db2.close();
   });
 });

--- a/test/unit/ui/addRepoWizard.test.ts
+++ b/test/unit/ui/addRepoWizard.test.ts
@@ -6,7 +6,9 @@ vi.mock('vscode', () => ({
     showInputBox: vi.fn(),
     showInformationMessage: vi.fn(),
     showWarningMessage: vi.fn(),
+    withProgress: vi.fn().mockImplementation((_opts: unknown, fn: () => unknown) => fn()),
   },
+  ProgressLocation: { Notification: 15 },
 }));
 
 import * as vscode from 'vscode';
@@ -42,6 +44,7 @@ describe('AddRepoWizard', () => {
     };
     browser = {
       listUserRepos: vi.fn().mockResolvedValue([]),
+      listAllUserRepos: vi.fn().mockResolvedValue([]),
     };
     dataSourceManager = {
       add: vi.fn().mockResolvedValue({ id: 'ds-1' }),
@@ -210,7 +213,7 @@ describe('AddRepoWizard', () => {
   });
 
   it('browses repos when user chooses browse', async () => {
-    browser.listUserRepos.mockResolvedValue([
+    browser.listAllUserRepos.mockResolvedValue([
       { owner: 'acme', repo: 'widgets', fullName: 'acme/widgets', description: 'Desc', private: false },
     ]);
 
@@ -237,7 +240,7 @@ describe('AddRepoWizard', () => {
     const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, configManager, embeddingRegistry);
     await wizard.run();
 
-    expect(browser.listUserRepos).toHaveBeenCalled();
+    expect(browser.listAllUserRepos).toHaveBeenCalled();
     expect(dataSourceManager.add).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- `src/storage/database.ts`: use `SCHEMA_VERSION` constant in `setSchemaVersion` call — fixes `no-unused-vars` lint error
- `test/unit/storage/database.test.ts`: update schema version assertions from `'2'` to `'3'`
- `test/unit/ui/addRepoWizard.test.ts`: add `ProgressLocation` and `withProgress` to vscode mock; add `listAllUserRepos` to browser mock; update browse test assertion
- `test/unit/ingestion/pipeline.test.ts`: mock the `/tarball/` endpoint — `fetchAllFiles` downloads a tarball, the old mock only handled `/git/blobs/`, so the pipeline got a 404 and stored 0 chunks

## Test plan
- [ ] CI lint job passes (no `no-unused-vars` on `SCHEMA_VERSION`)
- [ ] CI test job passes (database schema version, wizard browse, pipeline ingestion)
- [ ] Build job runs (depends on lint + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)