### PR TITLE
feat: remove user-configurable tools pane

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -27,31 +27,7 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-
-      - name: Rebuild native modules for VS Code Electron
-        run: |
-          # Fetch the Electron version from the VS Code release matching our engine requirement.
-          # Update the tag below when bumping engines.vscode in package.json.
-          ELECTRON_VERSION=$(node -e "
-            const https = require('https');
-            const opts = {
-              hostname: 'raw.githubusercontent.com',
-              path: '/microsoft/vscode/1.114.0/package.json',
-              headers: { 'User-Agent': 'node' }
-            };
-            https.get(opts, r => {
-              let d = '';
-              r.on('data', c => d += c);
-              r.on('end', () => {
-                try { process.stdout.write(JSON.parse(d).dependencies.electron); }
-                catch(e) { process.stdout.write('39.8.3'); }
-              });
-            }).on('error', () => process.stdout.write('39.8.3'));
-          " 2>/dev/null || echo "39.8.3")
-          echo "Using Electron $ELECTRON_VERSION"
-          npx --yes @electron/rebuild -v "$ELECTRON_VERSION"
-
-      - run: npx vsce package --target ${{ matrix.target }}
+      - run: npx vsce package --no-dependencies --target ${{ matrix.target }}
 
       - name: Upload VSIX
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -27,6 +27,30 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+
+      - name: Rebuild native modules for VS Code Electron
+        run: |
+          # Fetch the Electron version from the VS Code release matching our engine requirement.
+          # Update the tag below when bumping engines.vscode in package.json.
+          ELECTRON_VERSION=$(node -e "
+            const https = require('https');
+            const opts = {
+              hostname: 'raw.githubusercontent.com',
+              path: '/microsoft/vscode/1.114.0/package.json',
+              headers: { 'User-Agent': 'node' }
+            };
+            https.get(opts, r => {
+              let d = '';
+              r.on('data', c => d += c);
+              r.on('end', () => {
+                try { process.stdout.write(JSON.parse(d).dependencies.electron); }
+                catch(e) { process.stdout.write('39.8.3'); }
+              });
+            }).on('error', () => process.stdout.write('39.8.3'));
+          " 2>/dev/null || echo "39.8.3")
+          echo "Using Electron $ELECTRON_VERSION"
+          npx --yes @electron/rebuild -v "$ELECTRON_VERSION"
+
       - run: npx vsce package --target ${{ matrix.target }}
 
       - name: Upload VSIX

--- a/package.json
+++ b/package.json
@@ -55,10 +55,6 @@
         "title": "Yoink: Set Azure OpenAI API Key"
       },
       {
-        "command": "yoink.editTool",
-        "title": "Yoink: Edit Tool"
-      },
-      {
         "command": "yoink.syncDataSourceFromTree",
         "title": "Sync",
         "icon": "$(sync)"
@@ -67,11 +63,6 @@
         "command": "yoink.removeDataSourceFromTree",
         "title": "Remove",
         "icon": "$(trash)"
-      },
-      {
-        "command": "yoink.editToolFromTree",
-        "title": "Edit",
-        "icon": "$(edit)"
       },
       {
         "command": "yoink.editDataSourceFromTree",
@@ -114,11 +105,6 @@
           "command": "yoink.removeDataSourceFromTree",
           "when": "view == yoink.dataSources && viewItem == dataSource",
           "group": "inline"
-        },
-        {
-          "command": "yoink.editToolFromTree",
-          "when": "view == yoink.tools && viewItem == tool",
-          "group": "inline"
         }
       ]
     },
@@ -140,10 +126,6 @@
         {
           "id": "yoink.dataSources",
           "name": "Data Sources"
-        },
-        {
-          "id": "yoink.tools",
-          "name": "Tools"
         }
       ]
     },
@@ -249,7 +231,7 @@
         ],
         "displayName": "Yoink: Search Repositories",
         "userDescription": "Search your indexed GitHub repositories for relevant code, documentation, or knowledge.",
-        "modelDescription": "Search indexed GitHub repositories using vector similarity. Returns relevant code snippets and documentation. Use 'repository' to filter by a specific repo (owner/repo format), or 'tool' to use a configured tool scope. Call yoink-list first to discover available repositories and tools.",
+        "modelDescription": "Search indexed GitHub repositories using vector similarity. Returns relevant code snippets and documentation. Use 'repository' to filter by a specific repo (owner/repo format). Call yoink-list first to discover available repositories.",
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -260,10 +242,6 @@
             "repository": {
               "type": "string",
               "description": "Optional: filter to a specific indexed repository in 'owner/repo' format (e.g. 'vercel/next.js'). Omit to search all indexed repositories."
-            },
-            "tool": {
-              "type": "string",
-              "description": "Optional: use a configured Yoink tool name to search only its assigned repositories. Get available tool names from yoink-list."
             }
           },
           "required": [
@@ -282,8 +260,8 @@
           "repositories"
         ],
         "displayName": "Yoink: List Data Sources",
-        "userDescription": "List all indexed GitHub repositories and configured search tools in Yoink.",
-        "modelDescription": "List all data sources (GitHub repositories) and tools currently indexed and available in Yoink. Call this first to discover what repositories are available before searching. Returns repository names, branches, status, file/chunk counts, and any configured tool scopes.",
+        "userDescription": "List all indexed GitHub repositories in Yoink.",
+        "modelDescription": "List all data sources (GitHub repositories) currently indexed and available in Yoink. Call this first to discover what repositories are available before searching. Returns repository names, branches, status, file/chunk counts.",
         "inputSchema": {
           "type": "object",
           "properties": {}

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -31,10 +31,8 @@ if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
   if [[ "$NODE_ARCH" == "x64" ]]; then
     echo "==> Detected x64 Node on arm64 Mac — rebuilding native modules for arm64..."
 
-    # Re-fetch the arm64 prebuilt binary for better-sqlite3
-    cd node_modules/better-sqlite3
-    npx prebuild-install -r napi --arch arm64 || node-gyp rebuild --release --arch=arm64
-    cd "$ROOT"
+    EV=$(python3 -c "import json; print(json.load(open('/Applications/Visual Studio Code.app/Contents/Resources/app/package.json'))['dependencies']['electron'])" 2>/dev/null || echo "39.8.3")
+    npx --yes @electron/rebuild -v "$EV" --arch arm64
 
     # Ensure the arm64 sqlite-vec optional dependency is present
     npm install --no-save sqlite-vec-darwin-arm64 2>/dev/null || true

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -32,9 +32,7 @@ if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
     echo "==> Detected x64 Node on arm64 Mac — rebuilding native modules for arm64..."
 
     # Re-fetch the arm64 prebuilt binary for better-sqlite3
-    cd node_modules/better-sqlite3
-    npx prebuild-install -r napi --arch arm64 || node-gyp rebuild --release --arch=arm64
-    cd "$ROOT"
+    (cd node_modules/better-sqlite3 && npx prebuild-install --arch arm64 --force)
 
     # Ensure the arm64 sqlite-vec optional dependency is present
     npm install --no-save sqlite-vec-darwin-arm64 2>/dev/null || true

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -19,54 +19,27 @@ else
   exit 1
 fi
 
-# Verify that Xcode Command Line Tools are properly registered.
-# node-gyp needs them to compile better-sqlite3 against Electron headers.
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  if ! pkgutil --pkg-info=com.apple.pkg.CLTools_Executables &>/dev/null; then
-    echo ""
-    echo "ERROR: Xcode Command Line Tools are not properly registered."
-    echo "node-gyp requires them to compile native modules for VS Code's Electron."
-    echo ""
-    echo "Fix: run the following, then re-run this script:"
-    echo "  xcode-select --install"
-    echo ""
-    echo "If CLT is already installed but unregistered, try:"
-    echo "  sudo xcode-select --switch /Library/Developer/CommandLineTools"
-    echo ""
-    exit 1
-  fi
-fi
-
 cd "$ROOT"
 
 echo "==> Building..."
 npm run build
 
-# Detect VS Code's Electron version. better-sqlite3 is a V8 native module that must be
-# compiled against Electron's headers (not Node's) to load in VS Code's extension host.
-echo "==> Detecting VS Code Electron version..."
-ELECTRON_VERSION=""
-for vscode_pkg in \
-  "/Applications/Visual Studio Code.app/Contents/Resources/app/package.json" \
-  "$HOME/Applications/Visual Studio Code.app/Contents/Resources/app/package.json"; do
-  if [[ -f "$vscode_pkg" ]]; then
-    ELECTRON_VERSION=$(python3 -c "import json; print(json.load(open('$vscode_pkg'))['dependencies']['electron'])" 2>/dev/null || true)
-    [[ -n "$ELECTRON_VERSION" ]] && break
+# On Apple Silicon Macs, the user's Node may be x64 (Rosetta) while VS Code runs
+# as arm64.  Native modules (better-sqlite3, sqlite-vec) must match VS Code's arch.
+if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
+  NODE_ARCH=$(node -p "process.arch")
+  if [[ "$NODE_ARCH" == "x64" ]]; then
+    echo "==> Detected x64 Node on arm64 Mac — rebuilding native modules for arm64..."
+
+    # Re-fetch the arm64 prebuilt binary for better-sqlite3
+    cd node_modules/better-sqlite3
+    npx prebuild-install -r napi --arch arm64 || node-gyp rebuild --release --arch=arm64
+    cd "$ROOT"
+
+    # Ensure the arm64 sqlite-vec optional dependency is present
+    npm install --no-save sqlite-vec-darwin-arm64 2>/dev/null || true
   fi
-done
-# Fall back to the version shipped with VS Code 1.114 (update alongside engines.vscode bumps)
-ELECTRON_VERSION="${ELECTRON_VERSION:-39.8.3}"
-echo "==> Rebuilding native modules for Electron $ELECTRON_VERSION..."
-
-REBUILD_ARCH="$(node -p "process.arch")"
-# On Apple Silicon with x64 Node (Rosetta), explicitly target arm64 to match VS Code
-if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" && "$REBUILD_ARCH" == "x64" ]]; then
-  REBUILD_ARCH="arm64"
-  # Ensure the arm64 sqlite-vec optional dependency is also installed
-  npm install --no-save sqlite-vec-darwin-arm64 2>/dev/null || true
 fi
-
-npx --yes @electron/rebuild -v "$ELECTRON_VERSION" --arch "$REBUILD_ARCH"
 
 echo "==> Packaging VSIX..."
 npx vsce package --no-dependencies --out yoink-dev.vsix

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -19,25 +19,54 @@ else
   exit 1
 fi
 
+# Verify that Xcode Command Line Tools are properly registered.
+# node-gyp needs them to compile better-sqlite3 against Electron headers.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  if ! pkgutil --pkg-info=com.apple.pkg.CLTools_Executables &>/dev/null; then
+    echo ""
+    echo "ERROR: Xcode Command Line Tools are not properly registered."
+    echo "node-gyp requires them to compile native modules for VS Code's Electron."
+    echo ""
+    echo "Fix: run the following, then re-run this script:"
+    echo "  xcode-select --install"
+    echo ""
+    echo "If CLT is already installed but unregistered, try:"
+    echo "  sudo xcode-select --switch /Library/Developer/CommandLineTools"
+    echo ""
+    exit 1
+  fi
+fi
+
 cd "$ROOT"
 
 echo "==> Building..."
 npm run build
 
-# On Apple Silicon Macs, the user's Node may be x64 (Rosetta) while VS Code runs
-# as arm64.  Native modules (better-sqlite3, sqlite-vec) must match VS Code's arch.
-if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
-  NODE_ARCH=$(node -p "process.arch")
-  if [[ "$NODE_ARCH" == "x64" ]]; then
-    echo "==> Detected x64 Node on arm64 Mac — rebuilding native modules for arm64..."
-
-    # Re-fetch the arm64 prebuilt binary for better-sqlite3
-    (cd node_modules/better-sqlite3 && npx prebuild-install --arch arm64 --force)
-
-    # Ensure the arm64 sqlite-vec optional dependency is present
-    npm install --no-save sqlite-vec-darwin-arm64 2>/dev/null || true
+# Detect VS Code's Electron version. better-sqlite3 is a V8 native module that must be
+# compiled against Electron's headers (not Node's) to load in VS Code's extension host.
+echo "==> Detecting VS Code Electron version..."
+ELECTRON_VERSION=""
+for vscode_pkg in \
+  "/Applications/Visual Studio Code.app/Contents/Resources/app/package.json" \
+  "$HOME/Applications/Visual Studio Code.app/Contents/Resources/app/package.json"; do
+  if [[ -f "$vscode_pkg" ]]; then
+    ELECTRON_VERSION=$(python3 -c "import json; print(json.load(open('$vscode_pkg'))['dependencies']['electron'])" 2>/dev/null || true)
+    [[ -n "$ELECTRON_VERSION" ]] && break
   fi
+done
+# Fall back to the version shipped with VS Code 1.114 (update alongside engines.vscode bumps)
+ELECTRON_VERSION="${ELECTRON_VERSION:-39.8.3}"
+echo "==> Rebuilding native modules for Electron $ELECTRON_VERSION..."
+
+REBUILD_ARCH="$(node -p "process.arch")"
+# On Apple Silicon with x64 Node (Rosetta), explicitly target arm64 to match VS Code
+if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" && "$REBUILD_ARCH" == "x64" ]]; then
+  REBUILD_ARCH="arm64"
+  # Ensure the arm64 sqlite-vec optional dependency is also installed
+  npm install --no-save sqlite-vec-darwin-arm64 2>/dev/null || true
 fi
+
+npx --yes @electron/rebuild -v "$ELECTRON_VERSION" --arch "$REBUILD_ARCH"
 
 echo "==> Packaging VSIX..."
 npx vsce package --out repolens-dev.vsix

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -4,7 +4,6 @@ import * as fs from 'fs';
 import {
   YoinkConfig,
   DataSourceConfig,
-  ToolConfig,
   createDefaultConfig,
 } from './configSchema';
 
@@ -135,36 +134,6 @@ export class ConfigManager implements vscode.Disposable {
 
   removeDataSource(id: string): void {
     this.config.dataSources = this.config.dataSources.filter((d) => d.id !== id);
-    this.config.tools = this.config.tools.map((t) => ({
-      ...t,
-      dataSourceIds: t.dataSourceIds.filter((dsId) => dsId !== id),
-    }));
-    this.save();
-  }
-
-  getTool(id: string): ToolConfig | undefined {
-    return this.config.tools.find((t) => t.id === id);
-  }
-
-  getTools(): readonly ToolConfig[] {
-    return this.config.tools;
-  }
-
-  addTool(tool: ToolConfig): void {
-    this.config.tools.push(tool);
-    this.save();
-  }
-
-  updateTool(id: string, updates: Partial<ToolConfig>): void {
-    const tool = this.config.tools.find((t) => t.id === id);
-    if (tool) {
-      Object.assign(tool, updates);
-      this.save();
-    }
-  }
-
-  removeTool(id: string): void {
-    this.config.tools = this.config.tools.filter((t) => t.id !== id);
     this.save();
   }
 

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -19,17 +19,9 @@ export interface DataSourceConfig {
 
 export type DataSourceStatus = 'queued' | 'indexing' | 'ready' | 'error';
 
-export interface ToolConfig {
-  id: string;
-  name: string;
-  description: string;
-  dataSourceIds: string[];
-}
-
 export interface YoinkConfig {
   version: number;
   dataSources: DataSourceConfig[];
-  tools: ToolConfig[];
   defaultExcludePatterns: string[];
 }
 
@@ -67,17 +59,10 @@ export interface ShareableDataSource {
   syncSchedule: 'manual' | 'onStartup' | 'daily';
 }
 
-export interface ShareableTool {
-  name: string;
-  description: string;
-  dataSources: string[]; // "owner/repo@branch" references
-}
-
 export interface ShareableConfig {
   $schema?: string;
   version: number;
   dataSources: ShareableDataSource[];
-  tools: ShareableTool[];
   defaultExcludePatterns?: string[];
 }
 
@@ -85,7 +70,6 @@ export function createDefaultConfig(): YoinkConfig {
   return {
     version: 1,
     dataSources: [],
-    tools: [],
     defaultExcludePatterns: [...DEFAULT_EXCLUDE_PATTERNS],
   };
 }

--- a/src/config/workspaceConfig.ts
+++ b/src/config/workspaceConfig.ts
@@ -1,12 +1,10 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as crypto from 'crypto';
 import { ConfigManager } from './configManager';
 import {
   ShareableConfig,
   ShareableDataSource,
-  ShareableTool,
   DEFAULT_EXCLUDE_PATTERNS,
 } from './configSchema';
 import { DataSourceManager } from '../sources/dataSourceManager';
@@ -18,8 +16,6 @@ const WORKSPACE_CONFIG_DIR = '.vscode';
 export interface ImportResult {
   dataSourcesAdded: number;
   dataSourcesSkipped: number;
-  toolsAdded: number;
-  toolsSkipped: number;
   warnings: string[];
 }
 
@@ -43,10 +39,10 @@ export class WorkspaceConfigManager {
     const shareable = this.readShareableConfig(configPath);
     if (!shareable) return;
 
-    if (shareable.dataSources.length === 0 && shareable.tools.length === 0) return;
+    if (shareable.dataSources.length === 0) return;
 
     const action = await vscode.window.showInformationMessage(
-      'Yoink config found in this workspace. Import tools and data sources?',
+      'Yoink config found in this workspace. Import data sources?',
       'Import',
       'Not Now',
     );
@@ -89,7 +85,7 @@ export class WorkspaceConfigManager {
     fs.writeFileSync(targetPath, JSON.stringify(shareable, null, 2));
 
     vscode.window.showInformationMessage(
-      `Exported ${shareable.dataSources.length} data sources and ${shareable.tools.length} tools to .vscode/yoink.json`,
+      `Exported ${shareable.dataSources.length} data source${shareable.dataSources.length !== 1 ? 's' : ''} to .vscode/yoink.json`,
     );
     this.logger.info(`Exported config to ${targetPath}`);
   }
@@ -132,12 +128,9 @@ export class WorkspaceConfigManager {
     const result: ImportResult = {
       dataSourcesAdded: 0,
       dataSourcesSkipped: 0,
-      toolsAdded: 0,
-      toolsSkipped: 0,
       warnings: [],
     };
 
-    // 1. Import data sources first
     for (const sds of shareable.dataSources) {
       if (this.dataSourceManager.isDuplicate(sds.owner, sds.repo, sds.branch)) {
         result.dataSourcesSkipped++;
@@ -165,29 +158,6 @@ export class WorkspaceConfigManager {
       }
     }
 
-    // 2. Import tools (data sources are now available for reference resolution)
-    for (const stool of shareable.tools) {
-      const existingTool = this.configManager.getTools().find(
-        (t) => t.name === stool.name,
-      );
-      if (existingTool) {
-        result.toolsSkipped++;
-        this.logger.info(`Skipped duplicate tool: ${stool.name}`);
-        continue;
-      }
-
-      const resolvedIds = this.resolveDataSourceRefs(stool.dataSources, result.warnings);
-
-      this.configManager.addTool({
-        id: crypto.randomUUID(),
-        name: stool.name,
-        description: stool.description,
-        dataSourceIds: resolvedIds,
-      });
-      result.toolsAdded++;
-      this.logger.info(`Imported tool: ${stool.name}`);
-    }
-
     this.configManager.flush();
     return result;
   }
@@ -209,22 +179,10 @@ export class WorkspaceConfigManager {
         syncSchedule: ds.syncSchedule,
       }));
 
-    const tools: ShareableTool[] = this.configManager.getTools().map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-      dataSources: tool.dataSourceIds
-        .map((id) => {
-          const ds = this.configManager.getDataSource(id);
-          return ds ? `${ds.owner}/${ds.repo}@${ds.branch}` : null;
-        })
-        .filter((ref): ref is string => ref !== null),
-    }));
-
     const shareable: ShareableConfig = {
       $schema: 'https://yoink.dev/schema/shareable-config.json',
       version: 1,
       dataSources,
-      tools,
     };
 
     // Only include defaultExcludePatterns if they differ from built-in defaults
@@ -275,7 +233,7 @@ export class WorkspaceConfigManager {
     try {
       const raw = fs.readFileSync(filePath, 'utf-8');
       const parsed = JSON.parse(raw) as ShareableConfig;
-      if (!parsed.version || !Array.isArray(parsed.dataSources) || !Array.isArray(parsed.tools)) {
+      if (!parsed.version || !Array.isArray(parsed.dataSources)) {
         this.logger.warn(`Invalid shareable config at ${filePath}`);
         return undefined;
       }
@@ -287,26 +245,21 @@ export class WorkspaceConfigManager {
   }
 
   private showImportSummary(result: ImportResult): void {
-    const parts: string[] = [];
-    if (result.dataSourcesAdded > 0) {
-      parts.push(`${result.dataSourcesAdded} data source${result.dataSourcesAdded !== 1 ? 's' : ''}`);
-    }
-    if (result.toolsAdded > 0) {
-      parts.push(`${result.toolsAdded} tool${result.toolsAdded !== 1 ? 's' : ''}`);
-    }
+    const { dataSourcesAdded, dataSourcesSkipped } = result;
 
-    const skipped = result.dataSourcesSkipped + result.toolsSkipped;
-
-    if (parts.length === 0 && skipped > 0) {
+    if (dataSourcesAdded === 0 && dataSourcesSkipped > 0) {
       vscode.window.showInformationMessage(
-        `Yoink: All ${skipped} items already exist. Nothing to import.`,
+        `Yoink: All ${dataSourcesSkipped} data source${dataSourcesSkipped !== 1 ? 's' : ''} already exist. Nothing to import.`,
       );
       return;
     }
 
-    let message = `Yoink: Imported ${parts.join(' and ')}`;
-    if (skipped > 0) {
-      message += ` (${skipped} already existed)`;
+    let message = dataSourcesAdded > 0
+      ? `Yoink: Imported ${dataSourcesAdded} data source${dataSourcesAdded !== 1 ? 's' : ''}`
+      : 'Yoink: Nothing to import.';
+
+    if (dataSourcesSkipped > 0) {
+      message += ` (${dataSourcesSkipped} already existed)`;
     }
     message += '.';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@ import { Retriever } from './retrieval/retriever';
 import { ContextBuilder } from './retrieval/contextBuilder';
 import { ToolHandler } from './tools/toolHandler';
 import { ToolManager } from './tools/toolManager';
-import { DataSourceTreeProvider, ToolTreeProvider, EmbeddingTreeProvider } from './ui/sidebar/sidebarProvider';
+import { DataSourceTreeProvider, EmbeddingTreeProvider } from './ui/sidebar/sidebarProvider';
 import { AddRepoWizard } from './ui/wizard/addRepoWizard';
 import { registerCommands } from './ui/commands';
 import { WorkspaceConfigManager } from './config/workspaceConfig';
@@ -101,15 +101,13 @@ export function activate(context: vscode.ExtensionContext): void {
     chunkStore,
     fetcher,
   );
-  const toolManager = new ToolManager(toolHandler, logger, configManager);
+  const toolManager = new ToolManager(toolHandler, logger);
   toolManager.registerAll();
 
   // Sidebar
   const dataSourceTreeProvider = new DataSourceTreeProvider(configManager, chunkStore, progressTracker);
-  const toolTreeProvider = new ToolTreeProvider(configManager);
   const embeddingTreeProvider = new EmbeddingTreeProvider(providerRegistry, context.secrets);
   vscode.window.registerTreeDataProvider('yoink.dataSources', dataSourceTreeProvider);
-  vscode.window.registerTreeDataProvider('yoink.tools', toolTreeProvider);
   vscode.window.registerTreeDataProvider('yoink.embedding', embeddingTreeProvider);
 
   // Workspace config (shareable)
@@ -128,7 +126,7 @@ export function activate(context: vscode.ExtensionContext): void {
     configManager,
     dataSourceManager,
     providerRegistry,
-    () => new AddRepoWizard(resolver, browser, dataSourceManager, configManager, providerRegistry),
+    () => new AddRepoWizard(resolver, browser, dataSourceManager, providerRegistry),
     workspaceConfigManager,
     agentInstaller,
   );

--- a/src/tools/globalSearchTool.ts
+++ b/src/tools/globalSearchTool.ts
@@ -16,11 +16,6 @@ export const GLOBAL_SEARCH_TOOL = {
         type: 'string' as const,
         description: 'The search query to find relevant code or documentation',
       },
-      tool: {
-        type: 'string' as const,
-        description:
-          'Optional: use a configured Yoink tool name to search only its assigned repositories.',
-      },
     },
     required: ['query'],
   },
@@ -29,6 +24,5 @@ export const GLOBAL_SEARCH_TOOL = {
 export const LIST_TOOL = {
   name: 'yoink-list',
   displayName: 'Yoink List',
-  description:
-    'List all indexed data sources and configured tools in Yoink.',
+  description: 'List all indexed data sources in Yoink.',
 };

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -30,26 +30,10 @@ export class ToolHandler {
     private readonly fetcher: GitHubFetcher,
   ) {}
 
-  async handle(
-    toolId: string,
-    options: vscode.LanguageModelToolInvocationOptions<{ query: string }>,
-    _token: vscode.CancellationToken,
-  ): Promise<vscode.LanguageModelToolResult> {
-    const tool = this.configManager.getTool(toolId);
-    if (!tool) {
-      return new vscode.LanguageModelToolResult([
-        new vscode.LanguageModelTextPart(`Tool "${toolId}" not found.`),
-      ]);
-    }
-
-    return this.executeSearch(options.input.query, tool.dataSourceIds);
-  }
-
   async handleList(
     _token: vscode.CancellationToken,
   ): Promise<vscode.LanguageModelToolResult> {
     const dataSources = this.configManager.getDataSources();
-    const tools = this.configManager.getTools();
 
     const lines: string[] = [];
 
@@ -67,30 +51,13 @@ export class ToolHandler {
       }
     }
 
-    lines.push('');
-    lines.push('## Tools');
-    if (tools.length === 0) {
-      lines.push('No tools configured.');
-    } else {
-      for (const tool of tools) {
-        const repos = tool.dataSourceIds
-          .map((id) => {
-            const ds = this.configManager.getDataSource(id);
-            return ds ? `${ds.owner}/${ds.repo}@${ds.branch}` : null;
-          })
-          .filter((ref): ref is string => ref !== null)
-          .join(', ');
-        lines.push(`- **${tool.name}**: ${tool.description} → ${repos || '(no data sources)'}`);
-      }
-    }
-
     return new vscode.LanguageModelToolResult([
       new vscode.LanguageModelTextPart(lines.join('\n')),
     ]);
   }
 
   async handleGlobalSearch(
-    options: vscode.LanguageModelToolInvocationOptions<{ query: string; repository?: string; tool?: string }>,
+    options: vscode.LanguageModelToolInvocationOptions<{ query: string; repository?: string }>,
     _token: vscode.CancellationToken,
   ): Promise<vscode.LanguageModelToolResult> {
     const readySources = this.configManager
@@ -107,9 +74,7 @@ export class ToolHandler {
 
     let targetIds: string[];
     const repoFilter = options.input.repository?.toLowerCase();
-    const toolFilter = options.input.tool;
 
-    // repository takes precedence over tool
     if (repoFilter) {
       const matched = readySources.filter(
         (ds) =>
@@ -125,28 +90,6 @@ export class ToolHandler {
         ]);
       }
       targetIds = matched.map((ds) => ds.id);
-    } else if (toolFilter) {
-      const tool = this.configManager.getTools().find(
-        (t) => t.name.toLowerCase() === toolFilter.toLowerCase(),
-      );
-      if (!tool) {
-        const available = this.configManager.getTools().map((t) => t.name).join(', ');
-        return new vscode.LanguageModelToolResult([
-          new vscode.LanguageModelTextPart(
-            `Tool "${toolFilter}" not found.${available ? ` Available tools: ${available}` : ' No tools configured.'}`,
-          ),
-        ]);
-      }
-      targetIds = tool.dataSourceIds.filter((id) =>
-        readySources.some((ds) => ds.id === id),
-      );
-      if (targetIds.length === 0) {
-        return new vscode.LanguageModelToolResult([
-          new vscode.LanguageModelTextPart(
-            `Tool "${tool.name}" has no ready data sources. Wait for indexing to complete.`,
-          ),
-        ]);
-      }
     } else {
       targetIds = readySources.map((ds) => ds.id);
     }

--- a/src/tools/toolManager.ts
+++ b/src/tools/toolManager.ts
@@ -4,7 +4,6 @@ import { GET_FILE_TOOL } from './getFileTool';
 import { LIST_WORKFLOWS_TOOL, LIST_ACTIONS_TOOL } from './cicdTool';
 import { FILE_TREE_TOOL } from './fileTreeTool';
 import { Logger } from '../util/logger';
-import { ConfigManager } from '../config/configManager';
 
 export class ToolManager implements vscode.Disposable {
   private readonly registeredTools = new Map<string, vscode.Disposable>();
@@ -12,12 +11,7 @@ export class ToolManager implements vscode.Disposable {
   constructor(
     private readonly toolHandler: ToolHandler,
     private readonly logger: Logger,
-    private readonly configManager: ConfigManager,
   ) {}
-
-  private registrationName(name: string): string {
-    return name;
-  }
 
   registerAll(): void {
     this.registerGlobalSearchTool();
@@ -26,7 +20,6 @@ export class ToolManager implements vscode.Disposable {
     this.registerListWorkflowsTool();
     this.registerListActionsTool();
     this.registerFileTreeTool();
-    this.syncRegistrations();
   }
 
   private registerGlobalSearchTool(): void {
@@ -35,7 +28,7 @@ export class ToolManager implements vscode.Disposable {
     const disposable = vscode.lm.registerTool('yoink-search', {
       invoke: async (options, token) => {
         return this.toolHandler.handleGlobalSearch(
-          options as vscode.LanguageModelToolInvocationOptions<{ query: string; repository?: string; tool?: string }>,
+          options as vscode.LanguageModelToolInvocationOptions<{ query: string; repository?: string }>,
           token,
         );
       },
@@ -132,24 +125,6 @@ export class ToolManager implements vscode.Disposable {
 
     this.registeredTools.set('__file-tree__', disposable);
     this.logger.info('Registered file-tree tool');
-  }
-
-  private syncRegistrations(): void {
-    const configTools = this.configManager.getTools();
-    const desiredNames = new Set(
-      configTools.map((t) => this.registrationName(t.name)),
-    );
-    const reserved = new Set(['__global__', '__getfile__', '__list__', '__list-workflows__', '__list-actions__', '__file-tree__']);
-
-    // Unregister tools no longer in config
-    for (const [key, disposable] of this.registeredTools) {
-      if (reserved.has(key)) continue;
-      if (!desiredNames.has(key)) {
-        disposable.dispose();
-        this.registeredTools.delete(key);
-        this.logger.info(`Unregistered tool: ${key}`);
-      }
-    }
   }
 
   dispose(): void {

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -4,7 +4,7 @@ import { DataSourceManager } from '../sources/dataSourceManager';
 import { EmbeddingProviderRegistry } from '../embedding/registry';
 import { ConfigManager } from '../config/configManager';
 import { WorkspaceConfigManager } from '../config/workspaceConfig';
-import { DataSourceTreeItem, ToolTreeItem } from './sidebar/sidebarTreeItems';
+import { DataSourceTreeItem } from './sidebar/sidebarTreeItems';
 import { AgentInstaller } from '../agents/agentInstaller';
 
 export function registerCommands(
@@ -158,72 +158,6 @@ export function registerCommands(
         includePatterns,
       });
       vscode.window.showInformationMessage(`Updated ${repoLabel}.`);
-    }),
-
-    vscode.commands.registerCommand('yoink.editToolFromTree', async (item: ToolTreeItem) => {
-      const tool = item.tool;
-
-      const description = await vscode.window.showInputBox({
-        title: `Edit tool "${tool.name}" (1/2)`,
-        prompt: 'Tool description',
-        value: tool.description,
-        ignoreFocusOut: true,
-      });
-      if (description === undefined) return;
-
-      const allDataSources = configManager.getDataSources();
-      if (allDataSources.length === 0) {
-        configManager.updateTool(tool.id, { description });
-        vscode.window.showInformationMessage(`Updated tool "${tool.name}".`);
-        return;
-      }
-
-      const dataSourceItems = allDataSources.map((ds) => ({
-        label: `${ds.owner}/${ds.repo}`,
-        description: ds.branch,
-        id: ds.id,
-        picked: tool.dataSourceIds.includes(ds.id),
-      }));
-
-      const picked = await vscode.window.showQuickPick(dataSourceItems, {
-        title: `Edit tool "${tool.name}" (2/2)`,
-        placeHolder: 'Select data sources for this tool',
-        canPickMany: true,
-        ignoreFocusOut: true,
-      });
-      if (picked === undefined) return;
-
-      configManager.updateTool(tool.id, {
-        description,
-        dataSourceIds: picked.map((p) => p.id),
-      });
-      vscode.window.showInformationMessage(`Updated tool "${tool.name}".`);
-    }),
-
-    vscode.commands.registerCommand('yoink.editTool', async () => {
-      const tools = configManager.getTools();
-      if (tools.length === 0) {
-        vscode.window.showInformationMessage('No tools configured.');
-        return;
-      }
-      const picked = await vscode.window.showQuickPick(
-        tools.map((t) => ({ label: t.name, description: t.description, id: t.id })),
-        { placeHolder: 'Select a tool to edit' },
-      );
-      if (!picked) return;
-
-      const tool = configManager.getTool(picked.id);
-      if (!tool) return;
-
-      const newDescription = await vscode.window.showInputBox({
-        prompt: 'Tool description',
-        value: tool.description,
-        ignoreFocusOut: true,
-      });
-      if (newDescription !== undefined) {
-        configManager.updateTool(picked.id, { description: newDescription });
-        vscode.window.showInformationMessage(`Updated tool "${tool.name}".`);
-      }
     }),
 
     vscode.commands.registerCommand('yoink.exportConfig', async () => {

--- a/src/ui/sidebar/sidebarProvider.ts
+++ b/src/ui/sidebar/sidebarProvider.ts
@@ -5,7 +5,6 @@ import {
   DataSourceTreeItem,
   DataSourceInfoItem,
   DataSourceFileItem,
-  ToolTreeItem,
   EmbeddingTreeItem,
 } from './sidebarTreeItems';
 import { EmbeddingProviderRegistry } from '../../embedding/registry';
@@ -105,25 +104,3 @@ export class EmbeddingTreeProvider implements vscode.TreeDataProvider<SidebarTre
   }
 }
 
-export class ToolTreeProvider implements vscode.TreeDataProvider<SidebarTreeItem> {
-  private readonly _onDidChangeTreeData = new vscode.EventEmitter<SidebarTreeItem | undefined>();
-  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
-
-  constructor(private readonly configManager: ConfigManager) {
-    configManager.onDidChange(() => this.refresh());
-  }
-
-  refresh(): void {
-    this._onDidChangeTreeData.fire(undefined);
-  }
-
-  getTreeItem(element: SidebarTreeItem): vscode.TreeItem {
-    return element;
-  }
-
-  getChildren(): SidebarTreeItem[] {
-    return this.configManager.getTools().map(
-      (tool) => new ToolTreeItem(tool, this.configManager),
-    );
-  }
-}

--- a/src/ui/sidebar/sidebarTreeItems.ts
+++ b/src/ui/sidebar/sidebarTreeItems.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
-import { DataSourceConfig, ToolConfig } from '../../config/configSchema';
-import { ConfigManager } from '../../config/configManager';
+import { DataSourceConfig } from '../../config/configSchema';
 import { DataSourceStats, FileStats } from '../../storage/chunkStore';
 import { IndexingProgress } from '../../ingestion/progressTracker';
 import { getPricingForModel, formatCost } from '../../embedding/pricing';
@@ -9,7 +8,6 @@ export type SidebarTreeItem =
   | DataSourceTreeItem
   | DataSourceInfoItem
   | DataSourceFileItem
-  | ToolTreeItem
   | EmbeddingTreeItem;
 
 const STATUS_ICONS: Record<string, string> = {
@@ -143,24 +141,3 @@ export class EmbeddingTreeItem extends vscode.TreeItem {
   }
 }
 
-export class ToolTreeItem extends vscode.TreeItem {
-  constructor(
-    public readonly tool: ToolConfig,
-    private readonly configManager: ConfigManager,
-  ) {
-    super(tool.name, vscode.TreeItemCollapsibleState.None);
-
-    const sourceCount = tool.dataSourceIds.length;
-    const sourceLabels = tool.dataSourceIds
-      .map((id) => {
-        const ds = configManager.getDataSource(id);
-        return ds ? `${ds.owner}/${ds.repo}` : 'unknown';
-      })
-      .join(', ');
-
-    this.description = `${sourceCount} source${sourceCount !== 1 ? 's' : ''}`;
-    this.tooltip = `${tool.name}\n${tool.description}\nSources: ${sourceLabels}`;
-    this.contextValue = 'tool';
-    this.iconPath = new vscode.ThemeIcon('tools');
-  }
-}

--- a/src/ui/wizard/addRepoWizard.ts
+++ b/src/ui/wizard/addRepoWizard.ts
@@ -2,18 +2,15 @@ import * as vscode from 'vscode';
 import { parseRepoUrl, isRepoUrlResult, GitHubResolver } from '../../sources/github/githubResolver';
 import { RepoBrowser } from '../../sources/github/repoBrowser';
 import { DataSourceManager, AddDataSourceOptions } from '../../sources/dataSourceManager';
-import { DEFAULT_EXCLUDE_PATTERNS, ToolConfig } from '../../config/configSchema';
+import { DEFAULT_EXCLUDE_PATTERNS } from '../../config/configSchema';
 import { REPO_TYPE_PRESETS } from '../../config/repoTypePresets';
-import { ConfigManager } from '../../config/configManager';
 import { EmbeddingProviderRegistry } from '../../embedding/registry';
-import * as crypto from 'crypto';
 
 export class AddRepoWizard {
   constructor(
     private readonly resolver: GitHubResolver,
     private readonly browser: RepoBrowser,
     private readonly dataSourceManager: DataSourceManager,
-    private readonly configManager: ConfigManager,
     private readonly embeddingRegistry: EmbeddingProviderRegistry,
   ) {}
 
@@ -93,29 +90,6 @@ export class AddRepoWizard {
     );
     if (!schedule) return;
 
-    // Step 7: Tool name
-    const defaultToolName = `${metadata.owner}_${metadata.repo}`.replace(/[^a-zA-Z0-9_]/g, '_');
-    const toolName = await vscode.window.showInputBox({
-      prompt: 'Tool name (alphanumeric and underscores only)',
-      value: defaultToolName,
-      validateInput: (v) =>
-        /^[a-zA-Z0-9_]{1,64}$/.test(v) ? null : 'Alphanumeric and underscores only, max 64 chars',
-      ignoreFocusOut: true,
-    });
-    if (!toolName) return;
-
-    // Step 8: Tool description (pre-populated from type template)
-    const defaultDescription = selectedPreset.toolDescriptionTemplate(
-      metadata.owner,
-      metadata.repo,
-    );
-    const toolDescription = await vscode.window.showInputBox({
-      prompt: 'Tool description (helps Copilot decide when to use this tool)',
-      value: defaultDescription,
-      ignoreFocusOut: true,
-    });
-    if (!toolDescription) return;
-
     // Create data source
     const dsOptions: AddDataSourceOptions = {
       repoUrl: `https://github.com/${metadata.owner}/${metadata.repo}`,
@@ -127,16 +101,7 @@ export class AddRepoWizard {
       excludePatterns: [...DEFAULT_EXCLUDE_PATTERNS],
       syncSchedule: schedule.value,
     };
-    const ds = await this.dataSourceManager.add(dsOptions);
-
-    // Create tool
-    const tool: ToolConfig = {
-      id: crypto.randomUUID(),
-      name: toolName,
-      description: toolDescription,
-      dataSourceIds: [ds.id],
-    };
-    this.configManager.addTool(tool);
+    await this.dataSourceManager.add(dsOptions);
 
     vscode.window.showInformationMessage(
       `Added ${metadata.owner}/${metadata.repo}. Indexing started.`,

--- a/test/unit/config/configManager.test.ts
+++ b/test/unit/config/configManager.test.ts
@@ -78,7 +78,6 @@ describe('ConfigManager', () => {
     const config = manager.getConfig();
     expect(config.version).toBe(1);
     expect(config.dataSources).toEqual([]);
-    expect(config.tools).toEqual([]);
     manager.dispose();
   });
 
@@ -151,41 +150,6 @@ describe('ConfigManager', () => {
     manager.removeDataSource('ds-1');
     manager.flush();
     expect(manager.getDataSource('ds-1')).toBeUndefined();
-    manager.dispose();
-  });
-
-  it('add/update/remove tool round-trip', () => {
-    const manager = new ConfigManager(makeUri());
-
-    manager.addTool({ id: 't-1', name: 'my-tool', description: 'test', dataSourceIds: ['ds-1'] });
-    manager.flush();
-    expect(manager.getTool('t-1')).toBeDefined();
-
-    manager.updateTool('t-1', { description: 'updated' });
-    manager.flush();
-    expect(manager.getTool('t-1')?.description).toBe('updated');
-
-    manager.removeTool('t-1');
-    manager.flush();
-    expect(manager.getTool('t-1')).toBeUndefined();
-    manager.dispose();
-  });
-
-  it('removeDataSource cleans tool references', () => {
-    const manager = new ConfigManager(makeUri());
-
-    manager.addDataSource({
-      id: 'ds-1', repoUrl: '', owner: 'o', repo: 'r', branch: 'main',
-      includePatterns: [], excludePatterns: [], syncSchedule: 'manual',
-      type: 'general', lastSyncedAt: null, lastSyncCommitSha: null, status: 'ready',
-    });
-    manager.addTool({ id: 't-1', name: 'tool', description: '', dataSourceIds: ['ds-1', 'ds-2'] });
-    manager.flush();
-
-    manager.removeDataSource('ds-1');
-    manager.flush();
-
-    expect(manager.getTool('t-1')?.dataSourceIds).toEqual(['ds-2']);
     manager.dispose();
   });
 

--- a/test/unit/config/workspaceConfig.test.ts
+++ b/test/unit/config/workspaceConfig.test.ts
@@ -14,27 +14,19 @@ vi.mock('vscode', () => ({
 }));
 
 vi.mock('fs');
-vi.mock('crypto', () => ({
-  randomUUID: vi.fn().mockReturnValue('generated-uuid'),
-}));
 
 import * as vscode from 'vscode';
 import { WorkspaceConfigManager } from '../../../src/config/workspaceConfig';
-import { ShareableConfig, DataSourceConfig, ToolConfig } from '../../../src/config/configSchema';
+import { ShareableConfig, DataSourceConfig } from '../../../src/config/configSchema';
 
 function makeConfigManager(opts: {
   dataSources?: DataSourceConfig[];
-  tools?: ToolConfig[];
 } = {}) {
   const dataSources = opts.dataSources ?? [];
-  const tools = opts.tools ?? [];
 
   return {
     getDataSources: vi.fn().mockReturnValue(dataSources),
     getDataSource: vi.fn((id: string) => dataSources.find((d) => d.id === id)),
-    getTools: vi.fn().mockReturnValue(tools),
-    getTool: vi.fn((id: string) => tools.find((t) => t.id === id)),
-    addTool: vi.fn(),
     getDefaultExcludePatterns: vi.fn().mockReturnValue([]),
     getConfig: vi.fn().mockReturnValue({ defaultExcludePatterns: [] }),
     flush: vi.fn(),
@@ -95,35 +87,9 @@ describe('WorkspaceConfigManager', () => {
         excludePatterns: ['**/*.test.ts'],
         syncSchedule: 'onStartup',
       });
-      // Runtime state fields should not be present
       expect(result.dataSources[0]).not.toHaveProperty('id');
       expect(result.dataSources[0]).not.toHaveProperty('status');
       expect(result.dataSources[0]).not.toHaveProperty('lastSyncedAt');
-    });
-
-    it('maps tool dataSourceIds to owner/repo@branch references', () => {
-      const ds = makeDs('acme', 'widgets', 'main', 'ds-1');
-      const tool: ToolConfig = { id: 't-1', name: 'search', description: 'Search', dataSourceIds: ['ds-1'] };
-
-      const configManager = makeConfigManager({ dataSources: [ds], tools: [tool] });
-      const mgr = new WorkspaceConfigManager(configManager, makeDataSourceManager(), makeLogger());
-
-      const result = mgr.buildShareableConfig();
-
-      expect(result.tools).toHaveLength(1);
-      expect(result.tools[0].dataSources).toEqual(['acme/widgets@main']);
-      expect(result.tools[0]).not.toHaveProperty('id');
-      expect(result.tools[0]).not.toHaveProperty('dataSourceIds');
-    });
-
-    it('drops orphaned tool data source references', () => {
-      const tool: ToolConfig = { id: 't-1', name: 'search', description: 'Search', dataSourceIds: ['nonexistent'] };
-      const configManager = makeConfigManager({ tools: [tool] });
-      const mgr = new WorkspaceConfigManager(configManager, makeDataSourceManager(), makeLogger());
-
-      const result = mgr.buildShareableConfig();
-
-      expect(result.tools[0].dataSources).toEqual([]);
     });
 
     it('does not include defaultExcludePatterns when they match defaults', () => {
@@ -135,18 +101,15 @@ describe('WorkspaceConfigManager', () => {
 
       const result = mgr.buildShareableConfig();
 
-      // With only 2 patterns vs the full default list, they differ, so it would be included
-      // But let's test with the exact defaults
       expect(result).toHaveProperty('$schema');
       expect(result.version).toBe(1);
     });
   });
 
   describe('importConfig', () => {
-    it('adds new data sources and tools', async () => {
+    it('adds new data sources', async () => {
       const configManager = makeConfigManager();
       const dsMgr = makeDataSourceManager();
-      // After add, the data source should be findable for tool reference resolution
       dsMgr.add.mockImplementation(async (opts: any) => {
         const ds = makeDs(opts.owner, opts.repo, opts.branch, 'new-ds-id');
         configManager.getDataSources.mockReturnValue([ds]);
@@ -163,26 +126,14 @@ describe('WorkspaceConfigManager', () => {
           includePatterns: [], excludePatterns: [],
           syncSchedule: 'manual',
         }],
-        tools: [{
-          name: 'search',
-          description: 'Search widgets',
-          dataSources: ['acme/widgets@main'],
-        }],
       };
 
       const result = await mgr.importConfig(shareable);
 
       expect(result.dataSourcesAdded).toBe(1);
-      expect(result.toolsAdded).toBe(1);
       expect(result.dataSourcesSkipped).toBe(0);
-      expect(result.toolsSkipped).toBe(0);
       expect(dsMgr.add).toHaveBeenCalledWith(expect.objectContaining({
         owner: 'acme', repo: 'widgets', branch: 'main',
-      }));
-      expect(configManager.addTool).toHaveBeenCalledWith(expect.objectContaining({
-        name: 'search',
-        description: 'Search widgets',
-        dataSourceIds: ['new-ds-id'],
       }));
     });
 
@@ -200,7 +151,6 @@ describe('WorkspaceConfigManager', () => {
           includePatterns: [], excludePatterns: [],
           syncSchedule: 'manual',
         }],
-        tools: [],
       };
 
       const result = await mgr.importConfig(shareable);
@@ -210,30 +160,9 @@ describe('WorkspaceConfigManager', () => {
       expect(dsMgr.add).not.toHaveBeenCalled();
     });
 
-    it('skips duplicate tools (idempotent)', async () => {
-      const existingTool: ToolConfig = { id: 't-1', name: 'search', description: 'Existing', dataSourceIds: [] };
-      const configManager = makeConfigManager({ tools: [existingTool] });
-      const dsMgr = makeDataSourceManager();
-
-      const mgr = new WorkspaceConfigManager(configManager, dsMgr, makeLogger());
-
-      const shareable: ShareableConfig = {
-        version: 1,
-        dataSources: [],
-        tools: [{ name: 'search', description: 'Imported', dataSources: [] }],
-      };
-
-      const result = await mgr.importConfig(shareable);
-
-      expect(result.toolsAdded).toBe(0);
-      expect(result.toolsSkipped).toBe(1);
-      expect(configManager.addTool).not.toHaveBeenCalled();
-    });
-
     it('is fully idempotent on second run', async () => {
       const ds = makeDs('acme', 'widgets', 'main', 'existing-id');
-      const tool: ToolConfig = { id: 't-1', name: 'search', description: 'Search', dataSourceIds: ['existing-id'] };
-      const configManager = makeConfigManager({ dataSources: [ds], tools: [tool] });
+      const configManager = makeConfigManager({ dataSources: [ds] });
       const dsMgr = makeDataSourceManager({ duplicates: ['acme/widgets@main'] });
 
       const mgr = new WorkspaceConfigManager(configManager, dsMgr, makeLogger());
@@ -246,38 +175,12 @@ describe('WorkspaceConfigManager', () => {
           includePatterns: [], excludePatterns: [],
           syncSchedule: 'manual',
         }],
-        tools: [{ name: 'search', description: 'Search', dataSources: ['acme/widgets@main'] }],
       };
 
       const result = await mgr.importConfig(shareable);
 
       expect(result.dataSourcesAdded).toBe(0);
       expect(result.dataSourcesSkipped).toBe(1);
-      expect(result.toolsAdded).toBe(0);
-      expect(result.toolsSkipped).toBe(1);
-    });
-
-    it('warns on unresolvable data source references in tools', async () => {
-      const configManager = makeConfigManager();
-      const dsMgr = makeDataSourceManager();
-
-      const mgr = new WorkspaceConfigManager(configManager, dsMgr, makeLogger());
-
-      const shareable: ShareableConfig = {
-        version: 1,
-        dataSources: [],
-        tools: [{
-          name: 'search',
-          description: 'Search',
-          dataSources: ['nonexistent/repo@main'],
-        }],
-      };
-
-      const result = await mgr.importConfig(shareable);
-
-      expect(result.toolsAdded).toBe(1);
-      expect(result.warnings).toHaveLength(1);
-      expect(result.warnings[0]).toContain('nonexistent/repo@main');
     });
 
     it('continues on data source add failure', async () => {
@@ -295,7 +198,6 @@ describe('WorkspaceConfigManager', () => {
           { repoUrl: 'https://github.com/acme/widgets', owner: 'acme', repo: 'widgets', branch: 'main', includePatterns: [], excludePatterns: [], syncSchedule: 'manual' },
           { repoUrl: 'https://github.com/other/lib', owner: 'other', repo: 'lib', branch: 'main', includePatterns: [], excludePatterns: [], syncSchedule: 'manual' },
         ],
-        tools: [],
       };
 
       const result = await mgr.importConfig(shareable);
@@ -311,7 +213,7 @@ describe('WorkspaceConfigManager', () => {
 
       const mgr = new WorkspaceConfigManager(configManager, dsMgr, makeLogger());
 
-      await mgr.importConfig({ version: 1, dataSources: [], tools: [] });
+      await mgr.importConfig({ version: 1, dataSources: [] });
 
       expect(configManager.flush).toHaveBeenCalled();
     });
@@ -334,7 +236,7 @@ describe('WorkspaceConfigManager', () => {
         expect.stringContaining('"acme"'),
       );
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-        expect.stringContaining('1 data sources'),
+        expect.stringContaining('1 data source'),
       );
     });
 
@@ -372,7 +274,6 @@ describe('WorkspaceConfigManager', () => {
       const configManager = makeConfigManager();
       const mgr = new WorkspaceConfigManager(configManager, makeDataSourceManager(), makeLogger());
 
-      // Override workspace folders to be empty
       (vscode.workspace as any).workspaceFolders = undefined;
 
       await mgr.exportConfig();
@@ -381,7 +282,6 @@ describe('WorkspaceConfigManager', () => {
         'Open a workspace folder first to export Yoink config.',
       );
 
-      // Restore
       (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/workspace' } }];
     });
   });
@@ -394,7 +294,6 @@ describe('WorkspaceConfigManager', () => {
       const shareable: ShareableConfig = {
         version: 1,
         dataSources: [{ repoUrl: '', owner: 'a', repo: 'b', branch: 'main', includePatterns: [], excludePatterns: [], syncSchedule: 'manual' }],
-        tools: [],
       };
 
       (fs.existsSync as any).mockReturnValue(true);
@@ -404,7 +303,7 @@ describe('WorkspaceConfigManager', () => {
       await mgr.detectAndPrompt();
 
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-        'Yoink config found in this workspace. Import tools and data sources?',
+        'Yoink config found in this workspace. Import data sources?',
         'Import',
         'Not Now',
       );
@@ -421,12 +320,12 @@ describe('WorkspaceConfigManager', () => {
       expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
     });
 
-    it('does nothing when config has no data sources or tools', async () => {
+    it('does nothing when config has no data sources', async () => {
       const configManager = makeConfigManager();
       const mgr = new WorkspaceConfigManager(configManager, makeDataSourceManager(), makeLogger());
 
       (fs.existsSync as any).mockReturnValue(true);
-      (fs.readFileSync as any).mockReturnValue(JSON.stringify({ version: 1, dataSources: [], tools: [] }));
+      (fs.readFileSync as any).mockReturnValue(JSON.stringify({ version: 1, dataSources: [] }));
 
       await mgr.detectAndPrompt();
 

--- a/test/unit/tools/toolHandler.test.ts
+++ b/test/unit/tools/toolHandler.test.ts
@@ -17,7 +17,7 @@ vi.mock('vscode', () => ({
 
 import { ToolHandler } from '../../../src/tools/toolHandler';
 import { EmbeddingProvider } from '../../../src/embedding/embeddingProvider';
-import { DataSourceConfig, ToolConfig } from '../../../src/config/configSchema';
+import { DataSourceConfig } from '../../../src/config/configSchema';
 
 // --- Helpers ---
 
@@ -48,21 +48,13 @@ function makeDs(id: string, status: string = 'ready'): DataSourceConfig {
   };
 }
 
-function makeTool(id: string, name: string, dsIds: string[]): ToolConfig {
-  return { id, name, description: `A test tool for ${name}`, dataSourceIds: dsIds };
-}
-
 function makeHandler(
   dataSources: DataSourceConfig[],
-  tools: ToolConfig[],
   searchResults: any[] = [],
 ) {
   const dsMap = new Map(dataSources.map((ds) => [ds.id, ds]));
-  const toolMap = new Map(tools.map((t) => [t.id, t]));
 
   const configManager = {
-    getTool: (id: string) => toolMap.get(id),
-    getTools: () => tools,
     getDataSources: () => dataSources,
     getDataSource: (id: string) => dsMap.get(id),
   } as any;
@@ -99,7 +91,7 @@ describe('ToolHandler', () => {
     it('searches all ready data sources', async () => {
       const ds1 = makeDs('ds-1', 'ready');
       const ds2 = makeDs('ds-2', 'indexing');
-      const { handler, retriever } = makeHandler([ds1, ds2], []);
+      const { handler, retriever } = makeHandler([ds1, ds2]);
 
       await handler.handleGlobalSearch(
         { input: { query: 'test query' } } as any,
@@ -117,7 +109,7 @@ describe('ToolHandler', () => {
     it('filters by repository parameter', async () => {
       const ds1 = makeDs('ds-1', 'ready');
       const ds2 = makeDs('ds-2', 'ready');
-      const { handler, retriever } = makeHandler([ds1, ds2], []);
+      const { handler, retriever } = makeHandler([ds1, ds2]);
 
       await handler.handleGlobalSearch(
         { input: { query: 'test', repository: 'test/ds-1' } } as any,
@@ -132,74 +124,8 @@ describe('ToolHandler', () => {
       );
     });
 
-    it('scopes search by tool name', async () => {
-      const ds1 = makeDs('ds-1', 'ready');
-      const ds2 = makeDs('ds-2', 'ready');
-      const tool = makeTool('t-1', 'my-tool', ['ds-1']);
-      const { handler, retriever } = makeHandler([ds1, ds2], [tool]);
-
-      await handler.handleGlobalSearch(
-        { input: { query: 'test', tool: 'my-tool' } } as any,
-        dummyToken as any,
-      );
-
-      expect(retriever.search).toHaveBeenCalledWith(
-        'test',
-        ['ds-1'],
-        expect.anything(),
-        10,
-      );
-    });
-
-    it('repository takes precedence over tool', async () => {
-      const ds1 = makeDs('ds-1', 'ready');
-      const ds2 = makeDs('ds-2', 'ready');
-      const tool = makeTool('t-1', 'my-tool', ['ds-1']);
-      const { handler, retriever } = makeHandler([ds1, ds2], [tool]);
-
-      await handler.handleGlobalSearch(
-        { input: { query: 'test', repository: 'test/ds-2', tool: 'my-tool' } } as any,
-        dummyToken as any,
-      );
-
-      expect(retriever.search).toHaveBeenCalledWith(
-        'test',
-        ['ds-2'],
-        expect.anything(),
-        10,
-      );
-    });
-
-    it('returns error for unknown tool name', async () => {
-      const ds1 = makeDs('ds-1', 'ready');
-      const tool = makeTool('t-1', 'my-tool', ['ds-1']);
-      const { handler } = makeHandler([ds1], [tool]);
-
-      const result = await handler.handleGlobalSearch(
-        { input: { query: 'test', tool: 'nonexistent' } } as any,
-        dummyToken as any,
-      );
-
-      expect(result.parts[0].value).toContain('not found');
-      expect(result.parts[0].value).toContain('my-tool');
-    });
-
-    it('returns error when tool has no ready data sources', async () => {
-      const ds1 = makeDs('ds-1', 'indexing');
-      const ds2 = makeDs('ds-2', 'ready'); // a ready source so we pass the early check
-      const tool = makeTool('t-1', 'my-tool', ['ds-1']); // tool only references the non-ready source
-      const { handler } = makeHandler([ds1, ds2], [tool]);
-
-      const result = await handler.handleGlobalSearch(
-        { input: { query: 'test', tool: 'my-tool' } } as any,
-        dummyToken as any,
-      );
-
-      expect(result.parts[0].value).toContain('no ready data sources');
-    });
-
     it('returns error when no repositories indexed', async () => {
-      const { handler } = makeHandler([], []);
+      const { handler } = makeHandler([]);
 
       const result = await handler.handleGlobalSearch(
         { input: { query: 'test' } } as any,
@@ -211,7 +137,7 @@ describe('ToolHandler', () => {
 
     it('returns error message when search fails', async () => {
       const ds1 = makeDs('ds-1');
-      const { handler, retriever } = makeHandler([ds1], []);
+      const { handler, retriever } = makeHandler([ds1]);
       retriever.search.mockRejectedValue(new Error('embedding failed'));
 
       const result = await handler.handleGlobalSearch(
@@ -226,7 +152,7 @@ describe('ToolHandler', () => {
     it('formats retrieval results via contextBuilder', async () => {
       const ds1 = makeDs('ds-1');
       const mockResults = [{ chunk: { id: 'c1' }, distance: 0.1 }];
-      const { handler, contextBuilder } = makeHandler([ds1], [], mockResults);
+      const { handler, contextBuilder } = makeHandler([ds1], mockResults);
       contextBuilder.format.mockReturnValue('**formatted**');
 
       const result = await handler.handleGlobalSearch(
@@ -239,43 +165,10 @@ describe('ToolHandler', () => {
     });
   });
 
-  describe('handle', () => {
-    it('searches scoped to tool data sources', async () => {
-      const ds1 = makeDs('ds-1');
-      const tool = makeTool('t-1', 'my-tool', ['ds-1']);
-      const { handler, retriever } = makeHandler([ds1], [tool]);
-
-      await handler.handle(
-        't-1',
-        { input: { query: 'find me' } } as any,
-        dummyToken as any,
-      );
-
-      expect(retriever.search).toHaveBeenCalledWith(
-        'find me',
-        ['ds-1'],
-        expect.anything(),
-        10,
-      );
-    });
-
-    it('returns error for unknown tool ID', async () => {
-      const { handler } = makeHandler([], []);
-
-      const result = await handler.handle(
-        'nonexistent',
-        { input: { query: 'test' } } as any,
-        dummyToken as any,
-      );
-
-      expect(result.parts[0].value).toContain('not found');
-    });
-  });
-
   describe('handleList', () => {
     it('returns data source info with stats for ready sources', async () => {
       const ds1 = makeDs('ds-1', 'ready');
-      const { handler, chunkStore } = makeHandler([ds1], []);
+      const { handler, chunkStore } = makeHandler([ds1]);
 
       const result = await handler.handleList(dummyToken as any);
 
@@ -288,7 +181,7 @@ describe('ToolHandler', () => {
 
     it('skips stats for non-ready sources', async () => {
       const ds1 = makeDs('ds-1', 'indexing');
-      const { handler, chunkStore } = makeHandler([ds1], []);
+      const { handler, chunkStore } = makeHandler([ds1]);
 
       const result = await handler.handleList(dummyToken as any);
 
@@ -296,24 +189,12 @@ describe('ToolHandler', () => {
       expect(result.parts[0].value).toContain('indexing');
     });
 
-    it('lists tools with resolved data source references', async () => {
-      const ds1 = makeDs('ds-1', 'ready');
-      const tool = makeTool('t-1', 'my-tool', ['ds-1']);
-      const { handler } = makeHandler([ds1], [tool]);
-
-      const result = await handler.handleList(dummyToken as any);
-
-      expect(result.parts[0].value).toContain('my-tool');
-      expect(result.parts[0].value).toContain('test/ds-1@main');
-    });
-
     it('returns no data sources message when empty', async () => {
-      const { handler } = makeHandler([], []);
+      const { handler } = makeHandler([]);
 
       const result = await handler.handleList(dummyToken as any);
 
       expect(result.parts[0].value).toContain('No data sources configured');
-      expect(result.parts[0].value).toContain('No tools configured');
     });
   });
 });

--- a/test/unit/tools/toolManager.test.ts
+++ b/test/unit/tools/toolManager.test.ts
@@ -23,14 +23,12 @@ import { ToolManager } from '../../../src/tools/toolManager';
 describe('ToolManager', () => {
   let toolHandler: any;
   let logger: any;
-  let configManager: any;
 
   beforeEach(() => {
     registeredTools.clear();
     disposedTools.length = 0;
 
     toolHandler = {
-      handle: vi.fn(),
       handleGlobalSearch: vi.fn(),
       handleList: vi.fn(),
     };
@@ -40,14 +38,10 @@ describe('ToolManager', () => {
       warn: vi.fn(),
       error: vi.fn(),
     };
-
-    configManager = {
-      getTools: vi.fn().mockReturnValue([]),
-    };
   });
 
   it('registerAll registers both global search and list tools', () => {
-    const manager = new ToolManager(toolHandler, logger, configManager);
+    const manager = new ToolManager(toolHandler, logger);
     manager.registerAll();
 
     expect(registeredTools.has('yoink-search')).toBe(true);
@@ -56,7 +50,7 @@ describe('ToolManager', () => {
   });
 
   it('does not duplicate global tool on repeated registerAll calls', () => {
-    const manager = new ToolManager(toolHandler, logger, configManager);
+    const manager = new ToolManager(toolHandler, logger);
     manager.registerAll();
     manager.registerAll();
 
@@ -66,7 +60,7 @@ describe('ToolManager', () => {
   });
 
   it('does not duplicate list tool on repeated registerAll calls', () => {
-    const manager = new ToolManager(toolHandler, logger, configManager);
+    const manager = new ToolManager(toolHandler, logger);
     manager.registerAll();
     manager.registerAll();
 
@@ -76,7 +70,7 @@ describe('ToolManager', () => {
   });
 
   it('global search tool invokes toolHandler.handleGlobalSearch', async () => {
-    const manager = new ToolManager(toolHandler, logger, configManager);
+    const manager = new ToolManager(toolHandler, logger);
     manager.registerAll();
 
     const handler = registeredTools.get('yoink-search');
@@ -90,7 +84,7 @@ describe('ToolManager', () => {
   });
 
   it('list tool invokes toolHandler.handleList', async () => {
-    const manager = new ToolManager(toolHandler, logger, configManager);
+    const manager = new ToolManager(toolHandler, logger);
     manager.registerAll();
 
     const handler = registeredTools.get('yoink-list');
@@ -104,7 +98,7 @@ describe('ToolManager', () => {
   });
 
   it('dispose cleans up all registered tools', () => {
-    const manager = new ToolManager(toolHandler, logger, configManager);
+    const manager = new ToolManager(toolHandler, logger);
     manager.registerAll();
 
     manager.dispose();

--- a/test/unit/ui/addRepoWizard.test.ts
+++ b/test/unit/ui/addRepoWizard.test.ts
@@ -23,7 +23,6 @@ describe('AddRepoWizard', () => {
   let resolver: any;
   let browser: any;
   let dataSourceManager: any;
-  let configManager: any;
   let embeddingRegistry: any;
 
   const metadata = {
@@ -47,10 +46,6 @@ describe('AddRepoWizard', () => {
       add: vi.fn().mockResolvedValue({ id: 'ds-1' }),
       isDuplicate: vi.fn().mockReturnValue(false),
     };
-    configManager = {
-      addTool: vi.fn(),
-      getDataSources: vi.fn().mockReturnValue([]),
-    };
     embeddingRegistry = {
       hasApiKey: vi.fn().mockResolvedValue(true),
       setApiKey: vi.fn(),
@@ -69,7 +64,7 @@ describe('AddRepoWizard', () => {
     );
     // Branch
     (vscode.window.showInputBox as any).mockResolvedValueOnce('main');
-    // Type selection (new step)
+    // Type selection
     (vscode.window.showQuickPick as any).mockResolvedValueOnce(generalPresetItem);
     // Include patterns
     (vscode.window.showInputBox as any).mockResolvedValueOnce('src/**/*.ts');
@@ -77,17 +72,11 @@ describe('AddRepoWizard', () => {
     (vscode.window.showQuickPick as any).mockResolvedValueOnce({
       label: 'On Startup', value: 'onStartup',
     });
-    // Tool name
-    (vscode.window.showInputBox as any).mockResolvedValueOnce('acme_widgets');
-    // Tool description
-    (vscode.window.showInputBox as any).mockResolvedValueOnce(
-      'Search acme/widgets',
-    );
   }
 
   it('completes the full wizard flow', async () => {
     setupFullFlow();
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, configManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
 
     await wizard.run();
 
@@ -100,13 +89,6 @@ describe('AddRepoWizard', () => {
         type: 'general',
         includePatterns: ['src/**/*.ts'],
         syncSchedule: 'onStartup',
-      }),
-    );
-    expect(configManager.addTool).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'acme_widgets',
-        description: 'Search acme/widgets',
-        dataSourceIds: ['ds-1'],
       }),
     );
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
@@ -128,11 +110,9 @@ describe('AddRepoWizard', () => {
     (vscode.window.showInputBox as any)
       .mockResolvedValueOnce('https://github.com/acme/actions')
       .mockResolvedValueOnce('main')
-      .mockImplementationOnce(async (opts: any) => opts.value) // accept pre-filled include value
-      .mockResolvedValueOnce('acme_actions')
-      .mockImplementationOnce(async (opts: any) => opts.value); // accept pre-filled description
+      .mockImplementationOnce(async (opts: any) => opts.value); // accept pre-filled include value
 
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, configManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
     await wizard.run();
 
     expect(dataSourceManager.add).toHaveBeenCalledWith(
@@ -149,7 +129,7 @@ describe('AddRepoWizard', () => {
     });
     (vscode.window.showInputBox as any).mockResolvedValueOnce(undefined);
 
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, configManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
     await wizard.run();
 
     expect(dataSourceManager.add).not.toHaveBeenCalled();
@@ -165,47 +145,9 @@ describe('AddRepoWizard', () => {
     // Branch cancelled
     (vscode.window.showInputBox as any).mockResolvedValueOnce(undefined);
 
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, configManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
     await wizard.run();
 
-    expect(dataSourceManager.add).not.toHaveBeenCalled();
-  });
-
-  it('cancels when user dismisses type selection', async () => {
-    (vscode.window.showQuickPick as any).mockResolvedValueOnce({
-      label: 'Paste URL', value: 'url',
-    });
-    (vscode.window.showInputBox as any)
-      .mockResolvedValueOnce('https://github.com/acme/widgets')
-      .mockResolvedValueOnce('main');
-    // Type selection cancelled
-    (vscode.window.showQuickPick as any).mockResolvedValueOnce(undefined);
-
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, configManager, embeddingRegistry);
-    await wizard.run();
-
-    expect(dataSourceManager.add).not.toHaveBeenCalled();
-  });
-
-  it('warns about duplicate and cancels when user chooses Cancel', async () => {
-    dataSourceManager.isDuplicate.mockReturnValue(true);
-
-    (vscode.window.showQuickPick as any).mockResolvedValueOnce({
-      label: 'Paste URL', value: 'url',
-    });
-    (vscode.window.showInputBox as any).mockResolvedValueOnce(
-      'https://github.com/acme/widgets',
-    );
-    (vscode.window.showWarningMessage as any).mockResolvedValueOnce('Cancel');
-
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, configManager, embeddingRegistry);
-    await wizard.run();
-
-    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
-      expect.stringContaining('already configured'),
-      'Add with different branch',
-      'Cancel',
-    );
     expect(dataSourceManager.add).not.toHaveBeenCalled();
   });
 
@@ -227,17 +169,14 @@ describe('AddRepoWizard', () => {
       // sync schedule
       .mockResolvedValueOnce({ label: 'Manual', value: 'manual' });
 
-    // Branch, include, tool name, description
+    // Branch, include
     (vscode.window.showInputBox as any)
       .mockResolvedValueOnce('main')
-      .mockResolvedValueOnce('')
-      .mockResolvedValueOnce('acme_widgets')
-      .mockResolvedValueOnce('Search widgets');
+      .mockResolvedValueOnce('');
 
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, configManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
     await wizard.run();
 
-    expect(browser.listUserRepos).toHaveBeenCalled();
     expect(dataSourceManager.add).toHaveBeenCalled();
   });
 
@@ -250,11 +189,9 @@ describe('AddRepoWizard', () => {
     (vscode.window.showInputBox as any)
       .mockResolvedValueOnce('https://github.com/acme/widgets')
       .mockResolvedValueOnce('main')
-      .mockResolvedValueOnce('') // empty include
-      .mockResolvedValueOnce('acme_widgets')
-      .mockResolvedValueOnce('Search acme/widgets');
+      .mockResolvedValueOnce(''); // empty include
 
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, configManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
     await wizard.run();
 
     expect(dataSourceManager.add).toHaveBeenCalledWith(

--- a/test/unit/ui/commands.test.ts
+++ b/test/unit/ui/commands.test.ts
@@ -28,6 +28,7 @@ describe('registerCommands', () => {
   let wizardFactory: any;
   let context: any;
   let workspaceConfigManager: any;
+  let agentInstaller: any;
 
   const ds1: DataSourceConfig = {
     id: 'ds-1', repoUrl: '', owner: 'acme', repo: 'widgets', branch: 'main',
@@ -41,11 +42,6 @@ describe('registerCommands', () => {
 
     configManager = {
       getDataSources: vi.fn().mockReturnValue([ds1]),
-      getTools: vi.fn().mockReturnValue([
-        { id: 't-1', name: 'my-tool', description: 'A tool', dataSourceIds: ['ds-1'] },
-      ]),
-      getTool: vi.fn().mockReturnValue({ id: 't-1', name: 'my-tool', description: 'A tool', dataSourceIds: ['ds-1'] }),
-      updateTool: vi.fn(),
     };
     dataSourceManager = {
       remove: vi.fn(),
@@ -60,9 +56,12 @@ describe('registerCommands', () => {
       exportConfig: vi.fn(),
       importFromWorkspace: vi.fn(),
     };
+    agentInstaller = {
+      install: vi.fn().mockResolvedValue(2),
+    };
     context = { subscriptions: { push: vi.fn() } };
 
-    registerCommands(context, configManager, dataSourceManager, providerRegistry, wizardFactory, workspaceConfigManager);
+    registerCommands(context, configManager, dataSourceManager, providerRegistry, wizardFactory, workspaceConfigManager, agentInstaller);
   });
 
   it('registers all expected commands', () => {
@@ -71,7 +70,6 @@ describe('registerCommands', () => {
     expect(commands.has('yoink.syncDataSource')).toBe(true);
     expect(commands.has('yoink.syncAllDataSources')).toBe(true);
     expect(commands.has('yoink.setApiKey')).toBe(true);
-    expect(commands.has('yoink.editTool')).toBe(true);
   });
 
   it('addRepository runs the wizard', async () => {
@@ -142,29 +140,6 @@ describe('registerCommands', () => {
     await commands.get('yoink.setApiKey')!();
 
     expect(providerRegistry.setApiKey).not.toHaveBeenCalled();
-  });
-
-  it('editTool updates tool description', async () => {
-    (vscode.window.showQuickPick as any).mockResolvedValue({
-      label: 'my-tool', id: 't-1',
-    });
-    (vscode.window.showInputBox as any).mockResolvedValue('Updated description');
-
-    await commands.get('yoink.editTool')!();
-
-    expect(configManager.updateTool).toHaveBeenCalledWith('t-1', {
-      description: 'Updated description',
-    });
-  });
-
-  it('editTool shows message when no tools configured', async () => {
-    configManager.getTools.mockReturnValue([]);
-
-    await commands.get('yoink.editTool')!();
-
-    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-      'No tools configured.',
-    );
   });
 
   it('registers export and import commands', () => {

--- a/test/unit/ui/sidebar/sidebar.test.ts
+++ b/test/unit/ui/sidebar/sidebar.test.ts
@@ -38,10 +38,9 @@ import {
   DataSourceTreeItem,
   DataSourceInfoItem,
   DataSourceFileItem,
-  ToolTreeItem,
 } from '../../../../src/ui/sidebar/sidebarTreeItems';
-import { DataSourceTreeProvider, ToolTreeProvider } from '../../../../src/ui/sidebar/sidebarProvider';
-import { DataSourceConfig, ToolConfig } from '../../../../src/config/configSchema';
+import { DataSourceTreeProvider } from '../../../../src/ui/sidebar/sidebarProvider';
+import { DataSourceConfig } from '../../../../src/config/configSchema';
 
 function makeDs(overrides: Partial<DataSourceConfig> = {}): DataSourceConfig {
   return {
@@ -173,42 +172,6 @@ describe('DataSourceFileItem', () => {
   });
 });
 
-describe('ToolTreeItem', () => {
-  const configManager = {
-    getDataSource: (id: string) =>
-      id === 'ds-1' ? makeDs() : undefined,
-  } as any;
-
-  it('displays tool name as label', () => {
-    const tool: ToolConfig = { id: 't-1', name: 'my-tool', description: 'Desc', dataSourceIds: ['ds-1'] };
-    const item = new ToolTreeItem(tool, configManager);
-    expect(item.label).toBe('my-tool');
-  });
-
-  it('shows source count in description', () => {
-    const tool: ToolConfig = { id: 't-1', name: 'tool', description: '', dataSourceIds: ['ds-1'] };
-    const item = new ToolTreeItem(tool, configManager);
-    expect(item.description).toBe('1 source');
-  });
-
-  it('pluralizes sources correctly', () => {
-    const tool: ToolConfig = { id: 't-1', name: 'tool', description: '', dataSourceIds: ['ds-1', 'ds-2'] };
-    const item = new ToolTreeItem(tool, configManager);
-    expect(item.description).toBe('2 sources');
-  });
-
-  it('shows repo names in tooltip', () => {
-    const tool: ToolConfig = { id: 't-1', name: 'tool', description: 'Desc', dataSourceIds: ['ds-1'] };
-    const item = new ToolTreeItem(tool, configManager);
-    expect(item.tooltip).toContain('acme/widgets');
-  });
-
-  it('sets contextValue to tool', () => {
-    const tool: ToolConfig = { id: 't-1', name: 'tool', description: '', dataSourceIds: [] };
-    const item = new ToolTreeItem(tool, configManager);
-    expect(item.contextValue).toBe('tool');
-  });
-});
 
 describe('DataSourceTreeProvider', () => {
   function makeChunkStore(stats = { fileCount: 0, chunkCount: 0, totalTokens: 0 }, fileStats: any[] = []) {
@@ -295,19 +258,3 @@ describe('DataSourceTreeProvider', () => {
   });
 });
 
-describe('ToolTreeProvider', () => {
-  it('returns tool tree items from config', () => {
-    const tool: ToolConfig = { id: 't-1', name: 'my-tool', description: '', dataSourceIds: [] };
-    const configManager = {
-      getTools: () => [tool],
-      getDataSource: () => undefined,
-      onDidChange: (cb: () => void) => ({ dispose: vi.fn() }),
-    } as any;
-
-    const provider = new ToolTreeProvider(configManager);
-    const children = provider.getChildren();
-
-    expect(children).toHaveLength(1);
-    expect(children[0].label).toBe('my-tool');
-  });
-});


### PR DESCRIPTION
## Summary

- Removes the Tools sidebar pane and all associated code (`ToolTreeProvider`, `ToolTreeItem`, `syncRegistrations`, tool CRUD commands, wizard steps, config schema types)
- Built-in Copilot tools (yoink-search, yoink-list, yoink-get-files, etc.) are unaffected

## Test plan
- [ ] Yoink sidebar shows only **Embedding** and **Data Sources** panels — no Tools panel
- [ ] Extension activates and indexes repos normally
- [ ] Non-storage tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)