### PR TITLE
Make 'Manual' the default sync schedule in Add Repo wizard

### DIFF
--- a/src/ui/wizard/addRepoWizard.ts
+++ b/src/ui/wizard/addRepoWizard.ts
@@ -80,14 +80,16 @@ export class AddRepoWizard {
       : [];
 
     // Step 6: Sync schedule
-    const schedule = await vscode.window.showQuickPick(
-      [
-        { label: 'On Startup', value: 'onStartup' as const },
-        { label: 'Daily', value: 'daily' as const },
-        { label: 'Manual', value: 'manual' as const },
-      ],
-      { placeHolder: 'Sync schedule', ignoreFocusOut: true },
-    );
+    const scheduleItems = [
+      { label: 'Manual', value: 'manual' as const },
+      { label: 'On Startup', value: 'onStartup' as const },
+      { label: 'Daily', value: 'daily' as const },
+    ];
+    const schedule = await vscode.window.showQuickPick(scheduleItems, {
+      placeHolder: 'Sync schedule',
+      activeItems: [scheduleItems[0]],
+      ignoreFocusOut: true,
+    });
     if (!schedule) return;
 
     // Create data source


### PR DESCRIPTION
### Motivation
- Make the "Manual" sync schedule the default selection in the Add Repo wizard so users who prefer manual sync do not need to reselect it.

### Description
- Reordered the schedule options by creating a `scheduleItems` array with `Manual` first and called `vscode.window.showQuickPick(scheduleItems, { activeItems: [scheduleItems[0]], ... })` to preselect Manual while keeping the rest of the logic (including `syncSchedule: schedule.value`) unchanged.

### Testing
- Ran TypeScript compilation (`tsc` / `yarn build`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e751de82f883209e41807eba573312)