### PR TITLE
fix: copy tiktoken_bg.wasm to dist so extension loads on Windows

### DIFF
--- a/scripts/copy-queries.mjs
+++ b/scripts/copy-queries.mjs
@@ -1,5 +1,5 @@
-// Copies tree-sitter query files from src/chunking/queries/ into
-// dist/queries/ so they ship with the VSIX. Invoked from `npm run build`.
+// Copies tree-sitter query files and tiktoken WASM into dist/ so they ship
+// with the VSIX. Invoked from `npm run build`.
 
 import { mkdir, readdir, copyFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
@@ -18,3 +18,10 @@ for (const name of queries) {
   await copyFile(join(srcDir, name), join(outDir, name));
 }
 console.log(`copy-queries: wrote ${queries.length} .scm files to ${outDir}`);
+
+// tiktoken loads tiktoken_bg.wasm relative to dist/extension.js at runtime
+await copyFile(
+  join(repoRoot, 'node_modules', 'tiktoken', 'tiktoken_bg.wasm'),
+  join(repoRoot, 'dist', 'tiktoken_bg.wasm'),
+);
+console.log('copy-queries: copied tiktoken_bg.wasm to dist/');


### PR DESCRIPTION
## Summary

- `tiktoken` loads `tiktoken_bg.wasm` at runtime relative to `dist/extension.js`, but esbuild only bundles JS — the WASM file was missing from the VSIX
- Adds a copy step to `scripts/copy-queries.mjs` (already runs as part of `npm run build`) to copy `tiktoken_bg.wasm` into `dist/`

## Root cause

Error on Windows: `Error: Missing tiktoken_bg.wasm` at extension activation. The WASM was present in `node_modules/tiktoken/` but not bundled into `dist/`.

## Test plan
- [ ] Extension activates without error on Windows
- [ ] `dist/tiktoken_bg.wasm` exists after `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)