### PR TITLE
[codex] Fix packaged tiktoken activation

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -2,6 +2,10 @@ name: _build
 
 on:
   workflow_call:
+    inputs:
+      vsix_version:
+        required: false
+        type: string
 
 jobs:
   build:
@@ -27,11 +31,23 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npx vsce package --no-dependencies --target ${{ matrix.target }}
+
+      - name: Resolve VSIX filename
+        id: vsix
+        shell: bash
+        run: |
+          VERSION="${{ inputs.vsix_version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION="$(node -p "require('./package.json').version")"
+          fi
+          NAME="$(node -p "require('./package.json').name")"
+          echo "file=${NAME}-${VERSION}-${{ matrix.target }}.vsix" >> "$GITHUB_OUTPUT"
+
+      - run: npx vsce package --no-dependencies --target ${{ matrix.target }} --out "${{ steps.vsix.outputs.file }}"
 
       - name: Upload VSIX
         uses: actions/upload-artifact@v4
         with:
           name: vsix-${{ matrix.target }}
-          path: '*.vsix'
+          path: ${{ steps.vsix.outputs.file }}
           retention-days: 7

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -31,6 +31,8 @@ jobs:
   build:
     needs: tag
     uses: ./.github/workflows/_build.yml
+    with:
+      vsix_version: ${{ github.event.inputs.version }}
 
   release:
     needs: [tag, build]

--- a/scripts/copy-queries.mjs
+++ b/scripts/copy-queries.mjs
@@ -1,5 +1,5 @@
-// Copies tree-sitter query files from src/chunking/queries/ into
-// dist/queries/ so they ship with the VSIX. Invoked from `npm run build`.
+// Copies tree-sitter query files and tiktoken WASM into dist/ so they ship
+// with the VSIX. Invoked from `npm run build`.
 
 import { mkdir, readdir, copyFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
@@ -18,3 +18,10 @@ for (const name of queries) {
   await copyFile(join(srcDir, name), join(outDir, name));
 }
 console.log(`copy-queries: wrote ${queries.length} .scm files to ${outDir}`);
+
+// tiktoken loads tiktoken_bg.wasm relative to dist/extension.js at runtime
+await copyFile(
+  join(repoRoot, 'node_modules', 'tiktoken', 'tiktoken_bg.wasm'),
+  join(repoRoot, 'dist', 'tiktoken_bg.wasm'),
+);
+console.log('copy-queries: copied tiktoken_bg.wasm to dist/');

--- a/src/embedding/azureOpenAIProvider.ts
+++ b/src/embedding/azureOpenAIProvider.ts
@@ -1,5 +1,6 @@
-import { encoding_for_model, type Tiktoken } from 'tiktoken';
 import { EmbeddingProvider, estimateTokens } from './embeddingProvider';
+import { encodingForModel } from './tiktokenLoader';
+import type { Tiktoken } from 'tiktoken';
 
 export interface AzureOpenAIProviderOptions {
   apiKey: string;
@@ -132,7 +133,7 @@ export class AzureOpenAIEmbeddingProvider implements EmbeddingProvider {
   private getTokenizer(): Tiktoken {
     if (!this.tokenizer) {
       // cl100k_base covers all current Azure OpenAI embedding models
-      this.tokenizer = encoding_for_model('text-embedding-3-small');
+      this.tokenizer = encodingForModel('text-embedding-3-small');
     }
     return this.tokenizer;
   }

--- a/src/embedding/openaiProvider.ts
+++ b/src/embedding/openaiProvider.ts
@@ -1,5 +1,6 @@
-import { encoding_for_model, type Tiktoken, type TiktokenModel } from 'tiktoken';
 import { EmbeddingProvider, estimateTokens } from './embeddingProvider';
+import { encodingForModel } from './tiktokenLoader';
+import type { Tiktoken } from 'tiktoken';
 
 export interface OpenAIProviderOptions {
   apiKey: string;
@@ -143,10 +144,10 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   private getTokenizer(): Tiktoken {
     if (!this.tokenizer) {
       try {
-        this.tokenizer = encoding_for_model(this.model as TiktokenModel);
+        this.tokenizer = encodingForModel(this.model);
       } catch {
         // Model not recognized by tiktoken — use cl100k_base (covers embedding models)
-        this.tokenizer = encoding_for_model('text-embedding-3-small');
+        this.tokenizer = encodingForModel('text-embedding-3-small');
       }
     }
     return this.tokenizer;

--- a/src/embedding/tiktokenLoader.ts
+++ b/src/embedding/tiktokenLoader.ts
@@ -1,0 +1,20 @@
+import type { Tiktoken, TiktokenModel } from 'tiktoken';
+
+type TiktokenModule = typeof import('tiktoken');
+
+let cachedModule: TiktokenModule | null = null;
+
+function getTiktokenModule(): TiktokenModule {
+  if (cachedModule === null) {
+    // Load tiktoken on demand so a packaged WASM resolution issue cannot
+    // fail extension activation before token counting is ever used.
+    cachedModule = require('tiktoken') as TiktokenModule;
+  }
+
+  return cachedModule;
+}
+
+export function encodingForModel(model: string): Tiktoken {
+  const { encoding_for_model } = getTiktokenModule();
+  return encoding_for_model(model as TiktokenModel);
+}

--- a/test/unit/embedding/tiktokenLoader.test.ts
+++ b/test/unit/embedding/tiktokenLoader.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('tiktoken lazy loading', () => {
+  afterEach(() => {
+    vi.doUnmock('tiktoken');
+    vi.resetModules();
+  });
+
+  it('loads the OpenAI provider module without initializing tiktoken', async () => {
+    vi.doMock('tiktoken', () => {
+      throw new Error('Missing tiktoken_bg.wasm');
+    });
+
+    const mod = await import('../../../src/embedding/openaiProvider');
+
+    expect(mod.OpenAIEmbeddingProvider).toBeDefined();
+  });
+
+  it('falls back to estimated token counts when OpenAI tokenizer init fails', async () => {
+    const { OpenAIEmbeddingProvider } = await import('../../../src/embedding/openaiProvider');
+    const provider = new OpenAIEmbeddingProvider({
+      apiKey: 'sk-test-key',
+      model: 'text-embedding-3-small',
+      baseUrl: 'https://api.openai.com/v1',
+    });
+
+    vi.spyOn(provider as never, 'getTokenizer').mockImplementation(() => {
+      throw new Error('Missing tiktoken_bg.wasm');
+    });
+
+    expect(provider.countTokens('1234')).toBe(1);
+  });
+
+  it('falls back to estimated token counts when Azure tokenizer init fails', async () => {
+    const { AzureOpenAIEmbeddingProvider } = await import('../../../src/embedding/azureOpenAIProvider');
+    const provider = new AzureOpenAIEmbeddingProvider({
+      apiKey: 'test-azure-key',
+      endpoint: 'https://myresource.openai.azure.com',
+      deploymentName: 'my-embedding-deployment',
+      apiVersion: '2024-02-01',
+      dimensions: 1536,
+    });
+
+    vi.spyOn(provider as never, 'getTokenizer').mockImplementation(() => {
+      throw new Error('Missing tiktoken_bg.wasm');
+    });
+
+    expect(provider.countTokens('1234')).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- copy `tiktoken_bg.wasm` into `dist/` so the packaged VSIX ships the tokenizer WASM alongside the bundled extension entrypoint
- lazy-load `tiktoken` from the embedding providers so a packaged WASM lookup failure cannot crash extension activation
- add regression coverage for lazy loading and tokenizer fallback behavior

## Root cause
The published VSIX could fail during extension activation while evaluating the eager `tiktoken` import. When that happened, activation aborted before commands were registered, which surfaced in VS Code as `yoink.command was not found`.

## Impact
This keeps packaged installs from failing closed during activation when the tokenizer asset cannot be resolved exactly as expected. In that scenario, token counting now falls back to the existing estimate path instead of taking down the extension.

## Validation
- `npx vitest run test/unit/embedding/openaiProvider.test.ts test/unit/embedding/azureOpenAIProvider.test.ts test/unit/embedding/tiktokenLoader.test.ts`
- `npm run build`
- `npm run package`
