### PR TITLE
[codex] Fix tiktoken loader lint

### DIFF
--- a/src/embedding/tiktokenLoader.ts
+++ b/src/embedding/tiktokenLoader.ts
@@ -1,14 +1,16 @@
+import { createRequire } from 'node:module';
 import type { Tiktoken, TiktokenModel } from 'tiktoken';
 
 type TiktokenModule = typeof import('tiktoken');
 
 let cachedModule: TiktokenModule | null = null;
+const runtimeRequire = createRequire(__filename);
 
 function getTiktokenModule(): TiktokenModule {
   if (cachedModule === null) {
     // Load tiktoken on demand so a packaged WASM resolution issue cannot
     // fail extension activation before token counting is ever used.
-    cachedModule = require('tiktoken') as TiktokenModule;
+    cachedModule = runtimeRequire('tiktoken') as TiktokenModule;
   }
 
   return cachedModule;


### PR DESCRIPTION
## Summary
- replace the direct `require()` call in `tiktokenLoader` with a `createRequire`-backed loader
- preserve the same synchronous lazy-load behavior for `tiktoken`
- satisfy the repo lint rule that forbids `require()` style imports

## Root cause
PR #43 introduced a lazy loader for `tiktoken`, but the implementation used a raw `require()` call. CI fails on `@typescript-eslint/no-require-imports` for that line.

## Validation
- `npm run lint`
- `npx vitest run test/unit/embedding/openaiProvider.test.ts test/unit/embedding/azureOpenAIProvider.test.ts test/unit/embedding/tiktokenLoader.test.ts`
