### PR TITLE
[codex] Add managed prerelease workflow

### DIFF
--- a/.github/workflows/managed-prerelease.yml
+++ b/.github/workflows/managed-prerelease.yml
@@ -1,0 +1,122 @@
+name: Managed Prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'How to advance the prerelease version'
+        required: true
+        default: continue
+        type: choice
+        options:
+          - continue
+          - patch
+          - minor
+          - major
+
+jobs:
+  plan:
+    name: Plan Next Prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      current_next_version: ${{ steps.compute.outputs.current_next_version }}
+      release_version: ${{ steps.compute.outputs.release_version }}
+      next_version: ${{ steps.compute.outputs.next_version }}
+    steps:
+      - name: Compute versions
+        id: compute
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
+        run: |
+          set -euo pipefail
+
+          CURRENT_NEXT="$(gh variable get NEXT_PRERELEASE_VERSION --repo "$GITHUB_REPOSITORY" 2>/dev/null || true)"
+          if [ -z "$CURRENT_NEXT" ]; then
+            CURRENT_NEXT="0.0.1-alpha.9"
+          fi
+
+          if [[ ! "$CURRENT_NEXT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-alpha\.([0-9]+)$ ]]; then
+            echo "NEXT_PRERELEASE_VERSION must look like x.y.z-alpha.n, got: $CURRENT_NEXT" >&2
+            exit 1
+          fi
+
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          PATCH="${BASH_REMATCH[3]}"
+          ALPHA="${BASH_REMATCH[4]}"
+
+          case "$RELEASE_TYPE" in
+            continue)
+              RELEASE_VERSION="$CURRENT_NEXT"
+              NEXT_VERSION="${MAJOR}.${MINOR}.${PATCH}-alpha.$((ALPHA + 1))"
+              ;;
+            patch)
+              PATCH="$((PATCH + 1))"
+              RELEASE_VERSION="${MAJOR}.${MINOR}.${PATCH}-alpha.1"
+              NEXT_VERSION="${MAJOR}.${MINOR}.${PATCH}-alpha.2"
+              ;;
+            minor)
+              MINOR="$((MINOR + 1))"
+              PATCH=0
+              RELEASE_VERSION="${MAJOR}.${MINOR}.${PATCH}-alpha.1"
+              NEXT_VERSION="${MAJOR}.${MINOR}.${PATCH}-alpha.2"
+              ;;
+            major)
+              MAJOR="$((MAJOR + 1))"
+              MINOR=0
+              PATCH=0
+              RELEASE_VERSION="${MAJOR}.${MINOR}.${PATCH}-alpha.1"
+              NEXT_VERSION="${MAJOR}.${MINOR}.${PATCH}-alpha.2"
+              ;;
+            *)
+              echo "Unsupported release_type: $RELEASE_TYPE" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "current_next_version=$CURRENT_NEXT" >> "$GITHUB_OUTPUT"
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Managed prerelease plan"
+            echo
+            echo "- Current next prerelease: \`$CURRENT_NEXT\`"
+            echo "- Requested release type: \`$RELEASE_TYPE\`"
+            echo "- Version to publish now: \`$RELEASE_VERSION\`"
+            echo "- Version stored for next time: \`$NEXT_VERSION\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  prerelease:
+    name: Publish Prerelease
+    needs: plan
+    uses: ./.github/workflows/prerelease.yml
+    with:
+      version: ${{ needs.plan.outputs.release_version }}
+    secrets: inherit
+
+  persist_state:
+    name: Persist Next Prerelease
+    needs: [plan, prerelease]
+    runs-on: ubuntu-latest
+    if: success()
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Update repository variable
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT_VERSION: ${{ needs.plan.outputs.next_version }}
+        run: |
+          set -euo pipefail
+          gh variable set NEXT_PRERELEASE_VERSION --body "$NEXT_VERSION" --repo "$GITHUB_REPOSITORY"
+          {
+            echo "## Stored next prerelease version"
+            echo
+            echo "- NEXT_PRERELEASE_VERSION: \`$NEXT_VERSION\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -7,6 +7,12 @@ on:
         description: 'Version to release (e.g. 0.0.1-alpha.2) — no "v" prefix'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 0.0.1-alpha.2) — no "v" prefix'
+        required: true
+        type: string
 
 jobs:
   tag:
@@ -21,7 +27,7 @@ jobs:
       - name: Create and push tag
         id: create
         run: |
-          TAG="v${{ github.event.inputs.version }}"
+          TAG="v${{ inputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "$TAG"
@@ -32,7 +38,7 @@ jobs:
     needs: tag
     uses: ./.github/workflows/_build.yml
     with:
-      vsix_version: ${{ github.event.inputs.version }}
+      vsix_version: ${{ inputs.version }}
 
   release:
     needs: [tag, build]


### PR DESCRIPTION
## Summary
- add a `Managed Prerelease` workflow that computes the next prerelease version from a GitHub repo variable and then calls the existing prerelease pipeline
- make the existing `Prerelease` workflow reusable via `workflow_call` so it can still be run manually or be invoked by the manager workflow
- persist the next prerelease version back to the `NEXT_PRERELEASE_VERSION` GitHub variable only after a successful prerelease run

## Versioning behavior
The repository variable `NEXT_PRERELEASE_VERSION` is seeded to `0.0.1-alpha.9`.

Workflow input behavior:
- `continue`: publish the stored next prerelease version, then increment the stored value to the next alpha
- `patch`: start a new patch prerelease train at `x.y.(z+1)-alpha.1`, then store `...-alpha.2`
- `minor`: start a new minor prerelease train at `x.(y+1).0-alpha.1`, then store `...-alpha.2`
- `major`: start a new major prerelease train at `(x+1).0.0-alpha.1`, then store `...-alpha.2`

## Why
This removes the need to type prerelease version strings by hand and gives you a single place in GitHub to track the next version to publish.

## Validation
- exercised the version increment logic in bash for `continue`, `patch`, `minor`, and `major`
- seeded and read back `NEXT_PRERELEASE_VERSION=0.0.1-alpha.9` via `gh variable`
