### PR TITLE
[codex] Package runtime dependencies in VSIX

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -3,6 +3,10 @@ name: _build
 on:
   workflow_call:
     inputs:
+      include_runtime_dependencies:
+        required: false
+        type: boolean
+        default: true
       vsix_version:
         required: false
         type: string
@@ -43,7 +47,15 @@ jobs:
           NAME="$(node -p "require('./package.json').name")"
           echo "file=${NAME}-${VERSION}-${{ matrix.target }}.vsix" >> "$GITHUB_OUTPUT"
 
-      - run: npx vsce package --target ${{ matrix.target }} --out "${{ steps.vsix.outputs.file }}"
+      - name: Package VSIX
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARGS=(--target "${{ matrix.target }}" --out "${{ steps.vsix.outputs.file }}")
+          if [ "${{ inputs.include_runtime_dependencies }}" != "true" ]; then
+            ARGS=(--no-dependencies "${ARGS[@]}")
+          fi
+          npx vsce package "${ARGS[@]}"
 
       - name: Upload VSIX
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -43,7 +43,7 @@ jobs:
           NAME="$(node -p "require('./package.json').name")"
           echo "file=${NAME}-${VERSION}-${{ matrix.target }}.vsix" >> "$GITHUB_OUTPUT"
 
-      - run: npx vsce package --no-dependencies --target ${{ matrix.target }} --out "${{ steps.vsix.outputs.file }}"
+      - run: npx vsce package --target ${{ matrix.target }} --out "${{ steps.vsix.outputs.file }}"
 
       - name: Upload VSIX
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,5 @@ jobs:
     name: Build
     needs: [lint, test]
     uses: ./.github/workflows/_build.yml
+    with:
+      include_runtime_dependencies: false

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -32,6 +32,7 @@ jobs:
     needs: tag
     uses: ./.github/workflows/_build.yml
     with:
+      include_runtime_dependencies: true
       vsix_version: ${{ github.event.inputs.version }}
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     if: "!contains(github.ref_name, '-')"
     uses: ./.github/workflows/_build.yml
+    with:
+      include_runtime_dependencies: true
 
   release:
     needs: build

--- a/package.json
+++ b/package.json
@@ -433,7 +433,7 @@
     "lint": "eslint src/",
     "test": "vitest run",
     "test:watch": "vitest",
-    "package": "vsce package --no-dependencies",
+    "package": "vsce package",
     "dev:install": "bash scripts/dev-install.sh",
     "rebuild:native": "electron-rebuild -v 39.8.3 --arch arm64 --only better-sqlite3,sqlite-vec"
   },

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -40,7 +40,7 @@ if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
 fi
 
 echo "==> Packaging VSIX..."
-npx vsce package --no-dependencies --out yoink-dev.vsix
+npx vsce package --out yoink-dev.vsix
 
 echo "==> Installing extension..."
 "$CODE" --install-extension yoink-dev.vsix --force


### PR DESCRIPTION
## Summary
- stop using `vsce package --no-dependencies` in the package script, dev install script, and reusable build workflow
- ensure published VSIX files include runtime `node_modules` such as `better-sqlite3` and `sqlite-vec`

## Root cause
The release pipeline was packaging VSIX artifacts with `--no-dependencies`, which stripped all runtime `node_modules` from the archive. That produced installable VSIX files that crashed at activation time with `Cannot find module 'better-sqlite3'`.

## Validation
- `npm run package`
- verified the generated VSIX contains `extension/node_modules/better-sqlite3/package.json`
- verified the generated VSIX contains `extension/node_modules/better-sqlite3/build/Release/better_sqlite3.node`
- verified the previously published `v0.0.1-alpha.8` Windows VSIX did **not** contain `better-sqlite3`, matching the failure report
