### PR TITLE
[codex] Rebuild native modules for release packaging

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -3,10 +3,18 @@ name: _build
 on:
   workflow_call:
     inputs:
+      electron_version:
+        required: false
+        type: string
+        default: '39.8.3'
       include_runtime_dependencies:
         required: false
         type: boolean
         default: true
+      rebuild_native_modules:
+        required: false
+        type: boolean
+        default: false
       vsix_version:
         required: false
         type: string
@@ -18,10 +26,13 @@ jobs:
       matrix:
         include:
           - target: linux-x64
+            arch: x64
             os: ubuntu-latest
           - target: darwin-arm64
+            arch: arm64
             os: macos-latest
           - target: win32-x64
+            arch: x64
             os: windows-latest
     runs-on: ${{ matrix.os }}
 
@@ -34,6 +45,19 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Rebuild native modules for VS Code Electron
+        if: ${{ inputs.rebuild_native_modules }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx electron-rebuild \
+            --module-dir . \
+            --version "${{ inputs.electron_version }}" \
+            --arch "${{ matrix.arch }}" \
+            --force \
+            --only better-sqlite3
+
       - run: npm run build
 
       - name: Resolve VSIX filename

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,4 @@ jobs:
     uses: ./.github/workflows/_build.yml
     with:
       include_runtime_dependencies: false
+      rebuild_native_modules: false

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -38,8 +38,10 @@ jobs:
     needs: tag
     uses: ./.github/workflows/_build.yml
     with:
+      electron_version: '39.8.3'
       include_runtime_dependencies: true
-      vsix_version: ${{ github.event.inputs.version }}
+      rebuild_native_modules: true
+      vsix_version: ${{ inputs.version }}
 
   release:
     needs: [tag, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,9 @@ jobs:
     if: "!contains(github.ref_name, '-')"
     uses: ./.github/workflows/_build.yml
     with:
+      electron_version: '39.8.3'
       include_runtime_dependencies: true
+      rebuild_native_modules: true
 
   release:
     needs: build


### PR DESCRIPTION
## Summary
- add release-only workflow inputs for native Electron rebuilds in the shared `_build` workflow
- rebuild `better-sqlite3` against Electron 39.8.3 during release and prerelease packaging
- keep CI builds lean by leaving native rebuilds disabled there
- normalize prerelease version wiring to use `inputs.version`

## Root cause
After we started including runtime dependencies in the VSIX, the packaged `better-sqlite3` binary was still being built by `npm ci` against plain Node 22 on the GitHub runner. VS Code's extension host is Electron-based and requires a different module ABI, which caused activation to fail with `NODE_MODULE_VERSION 127` vs `140`.

## Validation
- `npx electron-rebuild --module-dir . --version 39.8.3 --arch arm64 --force --only better-sqlite3`
- `npm run build`
