### PR TITLE
Add repo-local VSIX install and debug skills

### DIFF
--- a/.codex/skills/yoink-isolated-vscode-loop/SKILL.md
+++ b/.codex/skills/yoink-isolated-vscode-loop/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: yoink-isolated-vscode-loop
+description: Use when you need to reproduce Yoink install and activation issues in normal VS Code with a clean, isolated profile. Builds or fetches a VSIX, installs it into an isolated extensions directory, launches a fresh VS Code window, and captures the session log paths and a grep summary for iteration.
+---
+
+# Yoink Isolated VS Code Loop
+
+Use this skill when the goal is to reproduce and iterate on installed-extension failures without using the extension development host.
+
+## Workflow
+
+1. Use the helper at [scripts/run-isolated-vscode.sh](scripts/run-isolated-vscode.sh).
+2. Default to `--source local-build` for iteration, because it is the fastest path from a code change to a repro outside the extension host.
+3. The script installs Yoink into a fresh `--extensions-dir` and launches VS Code with a fresh `--user-data-dir`, so each run is isolated.
+4. The script then waits for the session log directory to appear, writes a grep summary, and prints the exact paths for:
+   - run root
+   - user data dir
+   - extensions dir
+   - latest VS Code log dir
+   - log summary file
+   - installed VSIX path
+5. Use the generated log summary first. If needed, inspect the raw files under the printed log dir.
+6. For startup or activation failures, this is usually enough to self-iterate entirely from logs.
+7. For command-triggered failures, you still need the exact command id or click path. If UI interaction becomes necessary, use Computer Use or add a repo-local automation step later.
+
+## Recommended commands
+
+Run the default local-build loop with a clean profile:
+
+```bash
+bash .codex/skills/yoink-isolated-vscode-loop/scripts/run-isolated-vscode.sh --yes
+```
+
+Run faster local iterations by skipping `npm ci`:
+
+```bash
+bash .codex/skills/yoink-isolated-vscode-loop/scripts/run-isolated-vscode.sh --source local-build --skip-npm-ci --yes
+```
+
+Validate the latest release asset in an isolated profile:
+
+```bash
+bash .codex/skills/yoink-isolated-vscode-loop/scripts/run-isolated-vscode.sh --source release --yes
+```
+
+Open a different workspace while testing:
+
+```bash
+bash .codex/skills/yoink-isolated-vscode-loop/scripts/run-isolated-vscode.sh --workspace /absolute/path/to/workspace --yes
+```
+
+Reuse a known run directory so paths stay stable across attempts:
+
+```bash
+bash .codex/skills/yoink-isolated-vscode-loop/scripts/run-isolated-vscode.sh --run-dir /tmp/yoink-debug-run --source local-build --skip-npm-ci --yes
+```
+
+## Notes
+
+- This skill is the repo-local foundation for self-iteration on packaged-extension bugs.
+- It relies on the sibling `yoink-local-vsix-install` script to fetch or build the VSIX, so there is only one place to update packaging behavior.
+- The script launches a real VS Code window. It does not currently drive the UI after launch.
+- The log summary is a fast grep, not a full parser. If the failure is subtle, inspect the raw logs under the printed `LOG_DIR`.

--- a/.codex/skills/yoink-isolated-vscode-loop/agents/openai.yaml
+++ b/.codex/skills/yoink-isolated-vscode-loop/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Yoink Isolated VS Code Loop
+short_description: Launch Yoink in a clean VS Code profile, then collect the run's log paths and a quick failure summary.
+default_prompt: Reproduce Yoink in a clean installed-extension flow by building or fetching a VSIX, installing it into an isolated VS Code profile, launching VS Code, and summarizing the resulting logs for iteration.

--- a/.codex/skills/yoink-isolated-vscode-loop/scripts/run-isolated-vscode.sh
+++ b/.codex/skills/yoink-isolated-vscode-loop/scripts/run-isolated-vscode.sh
@@ -1,0 +1,361 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${SKILL_DIR}/../../.." && pwd)"
+INSTALL_SCRIPT="${REPO_ROOT}/.codex/skills/yoink-local-vsix-install/scripts/install-vsix.sh"
+
+SOURCE="local-build"
+REPO="colbymk97/yoink"
+REPO_DIR="$REPO_ROOT"
+WORKSPACE="$REPO_ROOT"
+EXTENSION_ID="yoink.yoink"
+TARGET=""
+TAG=""
+ASSET=""
+RUN_DIR=""
+SETTLE_SECONDS=15
+ASSUME_YES=0
+COMMAND_TITLE=""
+RUN_NPM_CI=1
+INCLUDE_RUNTIME_DEPENDENCIES=1
+REBUILD_NATIVE_MODULES=1
+ELECTRON_VERSION="39.8.3"
+LATEST_LOG_DIR=""
+SUMMARY_PATH=""
+VSIX_PATH=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  run-isolated-vscode.sh [options]
+
+Options:
+  --source <release|local-build>    VSIX source mode (default: local-build)
+  --repo <owner/name>               GitHub repo for release mode (default: colbymk97/yoink)
+  --repo-dir <path>                 Local checkout for local-build mode (default: repo root)
+  --workspace <path>                Folder or workspace to open in VS Code (default: repo root)
+  --extension-id <publisher.name>   Extension id to install (default: yoink.yoink)
+  --tag <tag>                       Release tag for release mode
+  --asset <filename>                Exact release asset for release mode
+  --target <target>                 VSIX target, e.g. darwin-arm64
+  --run-dir <path>                  Reuse or create an explicit run directory
+  --command-title <title>           Run a command palette entry after launch (macOS only)
+  --settle-seconds <n>              Wait time after launch before scraping logs (default: 15)
+  --skip-npm-ci                     Local-build mode only: skip npm ci
+  --no-runtime-dependencies         Local-build mode only: package with --no-dependencies
+  --no-rebuild-native-modules       Local-build mode only: skip electron-rebuild
+  --electron-version <version>      Electron version for local native rebuild (default: 39.8.3)
+  --yes                             Skip interactive confirmation
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source)
+      SOURCE="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --repo-dir)
+      REPO_DIR="$2"
+      shift 2
+      ;;
+    --workspace)
+      WORKSPACE="$2"
+      shift 2
+      ;;
+    --extension-id)
+      EXTENSION_ID="$2"
+      shift 2
+      ;;
+    --tag)
+      TAG="$2"
+      shift 2
+      ;;
+    --asset)
+      ASSET="$2"
+      shift 2
+      ;;
+    --target)
+      TARGET="$2"
+      shift 2
+      ;;
+    --run-dir)
+      RUN_DIR="$2"
+      shift 2
+      ;;
+    --command-title)
+      COMMAND_TITLE="$2"
+      shift 2
+      ;;
+    --settle-seconds)
+      SETTLE_SECONDS="$2"
+      shift 2
+      ;;
+    --skip-npm-ci)
+      RUN_NPM_CI=0
+      shift
+      ;;
+    --no-runtime-dependencies)
+      INCLUDE_RUNTIME_DEPENDENCIES=0
+      shift
+      ;;
+    --no-rebuild-native-modules)
+      REBUILD_NATIVE_MODULES=0
+      shift
+      ;;
+    --electron-version)
+      ELECTRON_VERSION="$2"
+      shift 2
+      ;;
+    --yes)
+      ASSUME_YES=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+find_code_cli() {
+  if command -v code >/dev/null 2>&1; then
+    command -v code
+    return
+  fi
+
+  if [[ -x "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ]]; then
+    echo "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+    return
+  fi
+
+  if [[ -x "$HOME/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ]]; then
+    echo "$HOME/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+    return
+  fi
+
+  echo "VS Code CLI 'code' is required." >&2
+  exit 1
+}
+
+CODE_BIN="$(find_code_cli)"
+
+if [[ ! -x "$INSTALL_SCRIPT" ]]; then
+  echo "Missing install helper: $INSTALL_SCRIPT" >&2
+  exit 1
+fi
+
+if [[ -z "$RUN_DIR" ]]; then
+  RUN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/yoink-vscode-run.XXXXXX")"
+else
+  mkdir -p "$RUN_DIR"
+fi
+
+USER_DATA_DIR="${RUN_DIR}/user-data"
+EXTENSIONS_DIR="${RUN_DIR}/extensions"
+STDOUT_LOG="${RUN_DIR}/code-stdout.log"
+STDERR_LOG="${RUN_DIR}/code-stderr.log"
+SUMMARY_PATH="${RUN_DIR}/log-summary.txt"
+
+mkdir -p "$USER_DATA_DIR" "$EXTENSIONS_DIR"
+
+run_install_helper() {
+  local -a args
+  args=(
+    --source "$SOURCE"
+    --repo "$REPO"
+    --repo-dir "$REPO_DIR"
+    --extension-id "$EXTENSION_ID"
+    --extensions-dir "$EXTENSIONS_DIR"
+    --electron-version "$ELECTRON_VERSION"
+  )
+
+  if [[ "$ASSUME_YES" -eq 1 ]]; then
+    args+=(--yes)
+  fi
+  if [[ -n "$TARGET" ]]; then
+    args+=(--target "$TARGET")
+  fi
+  if [[ -n "$TAG" ]]; then
+    args+=(--tag "$TAG")
+  fi
+  if [[ -n "$ASSET" ]]; then
+    args+=(--asset "$ASSET")
+  fi
+  if [[ "$RUN_NPM_CI" -ne 1 ]]; then
+    args+=(--skip-npm-ci)
+  fi
+  if [[ "$INCLUDE_RUNTIME_DEPENDENCIES" -ne 1 ]]; then
+    args+=(--no-runtime-dependencies)
+  fi
+  if [[ "$REBUILD_NATIVE_MODULES" -ne 1 ]]; then
+    args+=(--no-rebuild-native-modules)
+  fi
+
+  local output
+  output="$(bash "$INSTALL_SCRIPT" "${args[@]}")"
+  printf '%s\n' "$output"
+  VSIX_PATH="$(printf '%s\n' "$output" | sed -n 's/^VSIX_PATH=//p' | tail -n 1)"
+}
+
+find_latest_log_dir() {
+  local logs_root="$USER_DATA_DIR/logs"
+  if [[ ! -d "$logs_root" ]]; then
+    return 1
+  fi
+
+  find "$logs_root" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null | sort | tail -n 1
+}
+
+wait_for_log_dir() {
+  local deadline now
+  deadline=$(( $(date +%s) + SETTLE_SECONDS + 20 ))
+  while true; do
+    if LATEST_LOG_DIR="$(find_latest_log_dir)"; then
+      if [[ -n "$LATEST_LOG_DIR" ]]; then
+        return 0
+      fi
+    fi
+    now="$(date +%s)"
+    if (( now >= deadline )); then
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+write_log_summary() {
+  {
+    echo "Run dir: ${RUN_DIR}"
+    echo "User data dir: ${USER_DATA_DIR}"
+    echo "Extensions dir: ${EXTENSIONS_DIR}"
+    echo "Workspace: ${WORKSPACE}"
+    echo "VSIX path: ${VSIX_PATH}"
+    echo "Code stdout: ${STDOUT_LOG}"
+    echo "Code stderr: ${STDERR_LOG}"
+    echo
+    if [[ -z "$LATEST_LOG_DIR" ]]; then
+      echo "No VS Code log directory was found."
+    else
+      echo "Latest log dir: ${LATEST_LOG_DIR}"
+      echo
+      echo "Files:"
+      find "$LATEST_LOG_DIR" -type f | sort
+      echo
+      echo "Activation matches:"
+      rg -n -i --max-columns 240 --max-columns-preview \
+        -e 'ExtensionService#_doActivateExtension yoink\.yoink' \
+        -e 'Activating extension yoink\.yoink' \
+        -e 'yoink\.yoink failed' \
+        "$LATEST_LOG_DIR" || true
+      echo
+      echo "Known runtime clues:"
+      rg -n -i --max-columns 240 --max-columns-preview \
+        -e 'command was not found' \
+        -e 'better-sqlite3' \
+        -e 'sqlite-vec' \
+        -e 'tiktoken' \
+        "$LATEST_LOG_DIR" || true
+      echo
+      echo "Error lines:"
+      rg -n -i --max-columns 240 --max-columns-preview \
+        -e '\[error\]' \
+        "$LATEST_LOG_DIR" || true
+    fi
+  } >"$SUMMARY_PATH"
+}
+
+run_command_if_requested() {
+  if [[ -z "$COMMAND_TITLE" ]]; then
+    return
+  fi
+
+  if [[ "$(uname -s)" != "Darwin" ]] || ! command -v osascript >/dev/null 2>&1; then
+    echo "Command trigger requested, but scripted command execution is only supported on macOS right now."
+    return
+  fi
+
+  echo "Attempting to run command palette entry: ${COMMAND_TITLE}"
+  if ! osascript <<APPLESCRIPT
+tell application "Visual Studio Code"
+  activate
+end tell
+delay 0.8
+tell application "System Events"
+  keystroke "p" using {command down, shift down}
+  delay 0.8
+  keystroke "${COMMAND_TITLE}"
+  delay 0.5
+  key code 36
+end tell
+APPLESCRIPT
+  then
+    echo "Command trigger failed. On macOS this usually means the terminal does not have Accessibility permission."
+  fi
+}
+
+if [[ "$ASSUME_YES" -ne 1 ]]; then
+  cat <<EOF
+Source mode:  ${SOURCE}
+Repo dir:     ${REPO_DIR}
+Workspace:    ${WORKSPACE}
+Run dir:      ${RUN_DIR}
+Settle time:  ${SETTLE_SECONDS}s
+EOF
+  read -r -p "Launch an isolated VS Code run with these settings? [y/N]: " confirm
+  case "$confirm" in
+    y|Y|yes|YES) ;;
+    *)
+      echo "Aborted."
+      exit 0
+      ;;
+  esac
+fi
+
+run_install_helper
+
+echo "Launching VS Code..."
+"$CODE_BIN" \
+  --user-data-dir "$USER_DATA_DIR" \
+  --extensions-dir "$EXTENSIONS_DIR" \
+  --new-window "$WORKSPACE" \
+  --sync off \
+  --log trace \
+  --log "${EXTENSION_ID}:trace" \
+  >"$STDOUT_LOG" 2>"$STDERR_LOG" &
+
+sleep 2
+run_command_if_requested
+
+echo "Waiting ${SETTLE_SECONDS}s for the session to settle..."
+sleep "$SETTLE_SECONDS"
+
+if wait_for_log_dir; then
+  :
+else
+  LATEST_LOG_DIR=""
+fi
+
+write_log_summary
+
+echo "Done."
+echo "RUN_DIR=${RUN_DIR}"
+echo "USER_DATA_DIR=${USER_DATA_DIR}"
+echo "EXTENSIONS_DIR=${EXTENSIONS_DIR}"
+echo "LOG_DIR=${LATEST_LOG_DIR}"
+echo "LOG_SUMMARY=${SUMMARY_PATH}"
+echo "CODE_STDOUT=${STDOUT_LOG}"
+echo "CODE_STDERR=${STDERR_LOG}"
+echo "VSIX_PATH=${VSIX_PATH}"

--- a/.codex/skills/yoink-local-vsix-install/SKILL.md
+++ b/.codex/skills/yoink-local-vsix-install/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: yoink-local-vsix-install
+description: Use when you need to build or fetch a Yoink VSIX and install it into normal VS Code outside the extension host. Supports either the latest GitHub release asset or a local build that mirrors the release workflow, and can install into the default extensions directory or a custom isolated one.
+---
+
+# Yoink Local VSIX Install
+
+Use this skill when the goal is to validate Yoink as an installed VS Code extension rather than in the extension development host.
+
+## Workflow
+
+1. Use the helper at [scripts/install-vsix.sh](scripts/install-vsix.sh).
+2. Choose a source mode:
+   - `release`: fetch a VSIX from GitHub releases
+   - `local-build`: build a VSIX locally with the same core steps as `.github/workflows/_build.yml`
+3. Default to repo `colbymk97/yoink`, repo dir at the current repository root, and extension id `yoink.yoink`.
+4. In `release` mode, let the script choose the latest non-draft release from `gh release list`, because this repo ships prereleases frequently.
+5. In `local-build` mode, the script mirrors the workflow build path:
+   - `npm ci`
+   - optional `electron-rebuild` for `better-sqlite3`
+   - `npm run build`
+   - `vsce package --target ... --out ...`
+6. Prefer `--prepare-only` when another script needs the VSIX path but will handle install/launch itself.
+7. Install globally by default, or pass `--extensions-dir` to install into an isolated VS Code extension directory.
+8. Summarize the chosen asset/build settings, the installed version, and any packaging mismatches.
+
+## Recommended commands
+
+Preview the latest release asset and prompt before installing:
+
+```bash
+bash .codex/skills/yoink-local-vsix-install/scripts/install-vsix.sh
+```
+
+Install the latest release asset for this machine into the default VS Code profile:
+
+```bash
+bash .codex/skills/yoink-local-vsix-install/scripts/install-vsix.sh --source release --yes
+```
+
+Build a local VSIX with release-like steps and install it:
+
+```bash
+bash .codex/skills/yoink-local-vsix-install/scripts/install-vsix.sh --source local-build --yes
+```
+
+Build locally but skip `npm ci` for faster iteration:
+
+```bash
+bash .codex/skills/yoink-local-vsix-install/scripts/install-vsix.sh --source local-build --skip-npm-ci --yes
+```
+
+Prepare a local VSIX without installing it:
+
+```bash
+bash .codex/skills/yoink-local-vsix-install/scripts/install-vsix.sh --source local-build --skip-npm-ci --prepare-only --yes
+```
+
+Install into a custom isolated extensions directory:
+
+```bash
+bash .codex/skills/yoink-local-vsix-install/scripts/install-vsix.sh --source local-build --skip-npm-ci --extensions-dir /tmp/yoink-exts --yes
+```
+
+## Notes
+
+- This skill keeps the logic repo-local so future Codex runs do not depend on `~/.codex/skills`.
+- `local-build` defaults to `npm ci` because that best matches release packaging. For faster local iteration, use `--skip-npm-ci`.
+- The native rebuild mirrors the current workflow and only rebuilds `better-sqlite3`. If CI changes, update this script to match `_build.yml`.
+- `code --list-extensions --show-versions` reports the extension manifest version, not the VSIX filename. If a prerelease asset name includes `-alpha.N` but `package.json` still says `0.0.1`, VS Code will still report `yoink.yoink@0.0.1`.

--- a/.codex/skills/yoink-local-vsix-install/agents/openai.yaml
+++ b/.codex/skills/yoink-local-vsix-install/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Yoink Local VSIX Install
+short_description: Build or fetch a Yoink VSIX and install it into local VS Code outside the extension host.
+default_prompt: Build or fetch a Yoink VSIX, install it into local VS Code outside the extension host, and summarize the resulting install state and any packaging pain points.

--- a/.codex/skills/yoink-local-vsix-install/scripts/install-vsix.sh
+++ b/.codex/skills/yoink-local-vsix-install/scripts/install-vsix.sh
@@ -1,0 +1,534 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+SOURCE="release"
+REPO="colbymk97/yoink"
+REPO_DIR="$REPO_ROOT"
+EXTENSION_ID="yoink.yoink"
+TAG=""
+ASSET=""
+TARGET=""
+ASSUME_YES=0
+RELOAD_WINDOW=0
+KEEP_ARTIFACTS=1
+RUN_NPM_CI=1
+INCLUDE_RUNTIME_DEPENDENCIES=1
+REBUILD_NATIVE_MODULES=1
+ELECTRON_VERSION="39.8.3"
+PREPARE_ONLY=0
+EXTENSIONS_DIR=""
+TMPDIR=""
+VSIX_PATH=""
+LOCAL_BUILD_VERSION=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  install-vsix.sh [options]
+
+Modes:
+  --source release      Download and install a VSIX from GitHub releases (default)
+  --source local-build  Build a local VSIX from this checkout, then install it
+
+Options:
+  --repo <owner/name>              GitHub repo for release mode (default: colbymk97/yoink)
+  --repo-dir <path>                Checkout path for local-build mode (default: repo root)
+  --extension-id <publisher.name>  Extension id to uninstall/install (default: yoink.yoink)
+  --extensions-dir <path>          Install into a custom VS Code extensions dir
+  --tag <tag>                      Release tag for release mode
+  --asset <filename>               Exact asset name for release mode
+  --target <target>                VSIX target, e.g. darwin-arm64, linux-x64, win32-x64
+  --electron-version <version>     Electron version for local native rebuild (default: 39.8.3)
+  --skip-npm-ci                    Local-build mode only: skip npm ci
+  --no-runtime-dependencies        Local-build mode only: package with --no-dependencies
+  --no-rebuild-native-modules      Local-build mode only: skip electron-rebuild
+  --prepare-only                   Fetch/build the VSIX but do not install it
+  --cleanup                        Remove the downloaded/built VSIX on exit
+  --yes                            Skip interactive confirmation
+  --reload-window                  Attempt best-effort VS Code reload after install
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source)
+      SOURCE="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --repo-dir)
+      REPO_DIR="$2"
+      shift 2
+      ;;
+    --extension-id)
+      EXTENSION_ID="$2"
+      shift 2
+      ;;
+    --extensions-dir)
+      EXTENSIONS_DIR="$2"
+      shift 2
+      ;;
+    --tag)
+      TAG="$2"
+      shift 2
+      ;;
+    --asset)
+      ASSET="$2"
+      shift 2
+      ;;
+    --target)
+      TARGET="$2"
+      shift 2
+      ;;
+    --electron-version)
+      ELECTRON_VERSION="$2"
+      shift 2
+      ;;
+    --skip-npm-ci)
+      RUN_NPM_CI=0
+      shift
+      ;;
+    --no-runtime-dependencies)
+      INCLUDE_RUNTIME_DEPENDENCIES=0
+      shift
+      ;;
+    --no-rebuild-native-modules)
+      REBUILD_NATIVE_MODULES=0
+      shift
+      ;;
+    --prepare-only)
+      PREPARE_ONLY=1
+      shift
+      ;;
+    --cleanup)
+      KEEP_ARTIFACTS=0
+      shift
+      ;;
+    --yes)
+      ASSUME_YES=1
+      shift
+      ;;
+    --reload-window)
+      RELOAD_WINDOW=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+find_code_cli() {
+  if command -v code >/dev/null 2>&1; then
+    command -v code
+    return
+  fi
+
+  if [[ -x "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ]]; then
+    echo "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+    return
+  fi
+
+  if [[ -x "$HOME/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ]]; then
+    echo "$HOME/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+    return
+  fi
+
+  echo "VS Code CLI 'code' is required." >&2
+  exit 1
+}
+
+CODE_BIN="$(find_code_cli)"
+
+detect_target() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "$os/$arch" in
+    Darwin/arm64) echo "darwin-arm64" ;;
+    Darwin/x86_64) echo "darwin-x64" ;;
+    Linux/x86_64) echo "linux-x64" ;;
+    MINGW*/*|MSYS*/*|CYGWIN*/*|Windows_NT/*) echo "win32-x64" ;;
+    *)
+      echo "Could not infer VSIX target for ${os}/${arch}. Pass --target explicitly." >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [[ -z "$TARGET" ]]; then
+  TARGET="$(detect_target)"
+fi
+
+arch_from_target() {
+  case "$1" in
+    *-arm64) echo "arm64" ;;
+    *-x64) echo "x64" ;;
+    *)
+      echo "Could not infer architecture from target: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+cleanup() {
+  if [[ -n "$TMPDIR" && -d "$TMPDIR" && "$KEEP_ARTIFACTS" -eq 0 ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+ensure_tmpdir() {
+  if [[ -z "$TMPDIR" ]]; then
+    TMPDIR="$(mktemp -d)"
+  fi
+}
+
+release_view_json() {
+  gh release view "$TAG" --repo "$REPO" --json tagName,name,isPrerelease,publishedAt,url,assets
+}
+
+recommend_asset_from_release() {
+  local release_json suffix
+  release_json="$1"
+  suffix="${TARGET}.vsix"
+  RELEASE_JSON="$release_json" python3 - "$suffix" <<'PY'
+import json, os, sys
+suffix = sys.argv[1]
+data = json.loads(os.environ["RELEASE_JSON"])
+for asset in data.get("assets", []):
+    name = asset.get("name", "")
+    if name.endswith(suffix):
+        print(name)
+        break
+PY
+}
+
+print_release_summary() {
+  local release_json="$1"
+  RELEASE_JSON="$release_json" TARGET_NAME="$TARGET" python3 - <<'PY'
+import json, os
+data = json.loads(os.environ["RELEASE_JSON"])
+print("Source mode: release")
+print(f"Release:     {data['tagName']}")
+print(f"Name:        {data.get('name') or data['tagName']}")
+print(f"URL:         {data['url']}")
+print(f"Target:      {os.environ['TARGET_NAME']}")
+print("Assets:")
+for idx, asset in enumerate(data.get("assets", []), start=1):
+    print(f"  {idx}. {asset['name']} ({asset['size']} bytes)")
+PY
+}
+
+select_release_asset() {
+  local release_json="$1" recommended_asset="$2"
+
+  if [[ -n "$ASSET" ]]; then
+    return
+  fi
+
+  if [[ "$ASSUME_YES" -eq 1 ]]; then
+    ASSET="$recommended_asset"
+    if [[ -z "$ASSET" ]]; then
+      ASSET="$(RELEASE_JSON="$release_json" python3 - <<'PY'
+import json, os
+data = json.loads(os.environ["RELEASE_JSON"])
+assets = data.get("assets", [])
+if not assets:
+    raise SystemExit("Release has no downloadable assets")
+print(assets[0]["name"])
+PY
+)"
+    fi
+    return
+  fi
+
+  local default_choice="1"
+  if [[ -n "$recommended_asset" ]]; then
+    default_choice="$(RELEASE_JSON="$release_json" python3 - "$recommended_asset" <<'PY'
+import json, os, sys
+target = sys.argv[1]
+data = json.loads(os.environ["RELEASE_JSON"])
+for idx, asset in enumerate(data.get("assets", []), start=1):
+    if asset.get("name") == target:
+        print(idx)
+        break
+else:
+    print(1)
+PY
+)"
+  fi
+
+  read -r -p "Select asset number to install [${default_choice}]: " choice
+  choice="${choice:-$default_choice}"
+  ASSET="$(RELEASE_JSON="$release_json" python3 - "$choice" <<'PY'
+import json, os, sys
+choice = int(sys.argv[1])
+data = json.loads(os.environ["RELEASE_JSON"])
+assets = data.get("assets", [])
+if choice < 1 or choice > len(assets):
+    raise SystemExit("Invalid asset choice")
+print(assets[choice - 1]["name"])
+PY
+)"
+}
+
+prepare_release_vsix() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI is required for release mode." >&2
+    exit 1
+  fi
+
+  if [[ -z "$TAG" ]]; then
+    TAG="$(gh release list --repo "$REPO" --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName')"
+  fi
+
+  if [[ -z "$TAG" || "$TAG" == "null" ]]; then
+    echo "Could not determine a release tag for $REPO." >&2
+    exit 1
+  fi
+
+  local release_json recommended_asset
+  release_json="$(release_view_json)"
+  print_release_summary "$release_json"
+  recommended_asset="$(recommend_asset_from_release "$release_json" || true)"
+  if [[ -n "$recommended_asset" ]]; then
+    echo "Recommended asset for this machine: $recommended_asset"
+  fi
+
+  select_release_asset "$release_json" "$recommended_asset"
+  if [[ -z "$ASSET" ]]; then
+    echo "Could not resolve an asset to install." >&2
+    exit 1
+  fi
+
+  if [[ "$ASSUME_YES" -ne 1 ]]; then
+    read -r -p "Use ${ASSET} from ${TAG}? [y/N]: " confirm
+    case "$confirm" in
+      y|Y|yes|YES) ;;
+      *)
+        echo "Aborted."
+        exit 0
+        ;;
+    esac
+  fi
+
+  ensure_tmpdir
+  echo "Downloading ${ASSET} from ${TAG}..."
+  gh release download "$TAG" --repo "$REPO" --pattern "$ASSET" --dir "$TMPDIR" --clobber
+  VSIX_PATH="$TMPDIR/$ASSET"
+}
+
+print_local_build_summary() {
+  cat <<EOF
+Source mode: local-build
+Repo dir:     ${REPO_DIR}
+Target:       ${TARGET}
+Electron:     ${ELECTRON_VERSION}
+npm ci:       $( [[ "$RUN_NPM_CI" -eq 1 ]] && echo yes || echo no )
+Rebuild ABI:  $( [[ "$REBUILD_NATIVE_MODULES" -eq 1 ]] && echo yes || echo no )
+Deps in VSIX: $( [[ "$INCLUDE_RUNTIME_DEPENDENCIES" -eq 1 ]] && echo yes || echo no )
+EOF
+}
+
+prepare_local_build_vsix() {
+  if [[ ! -f "${REPO_DIR}/package.json" ]]; then
+    echo "No package.json found in repo dir: ${REPO_DIR}" >&2
+    exit 1
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "npm is required for local-build mode." >&2
+    exit 1
+  fi
+
+  print_local_build_summary
+  if [[ "$ASSUME_YES" -ne 1 ]]; then
+    read -r -p "Build a local VSIX with these settings? [y/N]: " confirm
+    case "$confirm" in
+      y|Y|yes|YES) ;;
+      *)
+        echo "Aborted."
+        exit 0
+        ;;
+    esac
+  fi
+
+  if [[ "$RUN_NPM_CI" -eq 1 ]]; then
+    echo "Running npm ci..."
+    (cd "$REPO_DIR" && npm ci)
+  fi
+
+  if [[ "$INCLUDE_RUNTIME_DEPENDENCIES" -eq 1 ]]; then
+    echo "Ensuring sqlite-vec package for ${TARGET}..."
+    (cd "$REPO_DIR" && node scripts/ensure-sqlite-vec-target.mjs --target "$TARGET")
+  fi
+
+  if [[ "$REBUILD_NATIVE_MODULES" -eq 1 ]]; then
+    echo "Rebuilding native modules for Electron ${ELECTRON_VERSION}..."
+    (
+      cd "$REPO_DIR"
+      npx electron-rebuild \
+        --module-dir . \
+        --version "$ELECTRON_VERSION" \
+        --arch "$(arch_from_target "$TARGET")" \
+        --force \
+        --only better-sqlite3
+    )
+  fi
+
+  echo "Running npm run build..."
+  (cd "$REPO_DIR" && npm run build)
+
+  ensure_tmpdir
+  local package_name package_version
+  package_name="$(cd "$REPO_DIR" && node -p "require('./package.json').name")"
+  package_version="$(cd "$REPO_DIR" && node -p "require('./package.json').version")"
+  LOCAL_BUILD_VERSION="$package_version"
+  VSIX_PATH="$TMPDIR/${package_name}-${package_version}-${TARGET}.vsix"
+
+  echo "Packaging local VSIX..."
+  (
+    cd "$REPO_DIR"
+    ARGS=(--target "$TARGET" --out "$VSIX_PATH")
+    if [[ "$INCLUDE_RUNTIME_DEPENDENCIES" -ne 1 ]]; then
+      ARGS=(--no-dependencies "${ARGS[@]}")
+    fi
+    npx vsce package "${ARGS[@]}"
+  )
+}
+
+verify_vsix_exists() {
+  if [[ -z "$VSIX_PATH" || ! -f "$VSIX_PATH" ]]; then
+    echo "Expected VSIX was not found: ${VSIX_PATH}" >&2
+    exit 1
+  fi
+}
+
+code_args() {
+  if [[ -n "$EXTENSIONS_DIR" ]]; then
+    printf -- "--extensions-dir\0%s\0" "$EXTENSIONS_DIR"
+  fi
+}
+
+install_vsix() {
+  local current_install installed_after expected_version
+  local -a code_extra_args=()
+
+  if [[ -n "$EXTENSIONS_DIR" ]]; then
+    mkdir -p "$EXTENSIONS_DIR"
+    while IFS= read -r -d '' arg; do
+      code_extra_args+=("$arg")
+    done < <(code_args)
+  fi
+
+  current_install="$("$CODE_BIN" "${code_extra_args[@]}" --list-extensions --show-versions | rg "^${EXTENSION_ID}@" || true)"
+  if [[ -n "$current_install" ]]; then
+    echo "Currently installed: ${current_install}"
+    echo "Uninstalling ${EXTENSION_ID}..."
+    "$CODE_BIN" "${code_extra_args[@]}" --uninstall-extension "$EXTENSION_ID"
+  else
+    echo "No existing ${EXTENSION_ID} install found."
+  fi
+
+  echo "Installing ${VSIX_PATH}..."
+  "$CODE_BIN" "${code_extra_args[@]}" --install-extension "$VSIX_PATH" --force
+
+  installed_after="$("$CODE_BIN" "${code_extra_args[@]}" --list-extensions --show-versions | rg "^${EXTENSION_ID}@" || true)"
+  echo "Installed extension versions:"
+  echo "$installed_after"
+
+  if [[ "$SOURCE" == "release" ]]; then
+    expected_version="${TAG#v}"
+  else
+    expected_version="$LOCAL_BUILD_VERSION"
+  fi
+
+  if [[ -n "$installed_after" && "$installed_after" != *"@${expected_version}" ]]; then
+    echo "Note: installed extension version does not match the expected version string."
+    echo "      Expected: ${expected_version}"
+    echo "      Reported: ${installed_after}"
+    echo "      This usually means the packaged extension manifest version was not bumped to the same version as the asset/tag."
+  fi
+}
+
+reload_window_if_requested() {
+  if [[ "$RELOAD_WINDOW" -ne 1 ]]; then
+    return
+  fi
+
+  if [[ "$(uname -s)" == "Darwin" ]] && command -v osascript >/dev/null 2>&1; then
+    echo "Attempting best-effort VS Code window reload via AppleScript..."
+    if ! osascript <<'APPLESCRIPT'
+tell application "Visual Studio Code"
+  activate
+end tell
+delay 0.5
+tell application "System Events"
+  keystroke "p" using {command down, shift down}
+  delay 0.5
+  keystroke "Developer: Reload Window"
+  delay 0.3
+  key code 36
+end tell
+APPLESCRIPT
+    then
+      echo "Reload attempt failed. On macOS this usually means the terminal does not have Accessibility permission."
+      echo "Please use 'Developer: Reload Window' manually in VS Code."
+    fi
+  else
+    echo "Reload requested, but no supported scripted reload path is available on this machine."
+  fi
+}
+
+case "$SOURCE" in
+  release)
+    prepare_release_vsix
+    ;;
+  local-build)
+    prepare_local_build_vsix
+    ;;
+  *)
+    echo "Unsupported source mode: $SOURCE" >&2
+    exit 1
+    ;;
+esac
+
+verify_vsix_exists
+
+if [[ "$PREPARE_ONLY" -ne 1 ]]; then
+  install_vsix
+  reload_window_if_requested
+fi
+
+echo "Done."
+echo "Source mode: ${SOURCE}"
+if [[ "$SOURCE" == "release" ]]; then
+  echo "Release tag: ${TAG}"
+  echo "Asset: ${ASSET}"
+else
+  echo "Built target: ${TARGET}"
+  echo "Repo dir: ${REPO_DIR}"
+fi
+if [[ -n "$EXTENSIONS_DIR" ]]; then
+  echo "Extensions dir: ${EXTENSIONS_DIR}"
+fi
+echo "VSIX_PATH=${VSIX_PATH}"
+if [[ "$KEEP_ARTIFACTS" -eq 1 ]]; then
+  echo "Artifact kept on disk."
+else
+  echo "Artifact will be cleaned up on exit."
+fi

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -3,10 +3,18 @@ name: _build
 on:
   workflow_call:
     inputs:
+      electron_version:
+        required: false
+        type: string
+        default: '39.8.3'
       include_runtime_dependencies:
         required: false
         type: boolean
         default: true
+      rebuild_native_modules:
+        required: false
+        type: boolean
+        default: false
       vsix_version:
         required: false
         type: string
@@ -18,10 +26,13 @@ jobs:
       matrix:
         include:
           - target: linux-x64
+            arch: x64
             os: ubuntu-latest
           - target: darwin-arm64
+            arch: arm64
             os: macos-latest
           - target: win32-x64
+            arch: x64
             os: windows-latest
     runs-on: ${{ matrix.os }}
 
@@ -34,6 +45,19 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Rebuild native modules for VS Code Electron
+        if: ${{ inputs.rebuild_native_modules }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx electron-rebuild \
+            --module-dir . \
+            --version "${{ inputs.electron_version }}" \
+            --arch "${{ matrix.arch }}" \
+            --force \
+            --only better-sqlite3
+
       - run: npm run build
 
       - name: Resolve VSIX filename

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -46,6 +46,10 @@ jobs:
 
       - run: npm ci
 
+      - name: Ensure sqlite-vec package for target
+        shell: bash
+        run: node scripts/ensure-sqlite-vec-target.mjs --target "${{ matrix.target }}"
+
       - name: Rebuild native modules for VS Code Electron
         if: ${{ inputs.rebuild_native_modules }}
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,4 @@ jobs:
     uses: ./.github/workflows/_build.yml
     with:
       include_runtime_dependencies: false
+      rebuild_native_modules: false

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -38,8 +38,10 @@ jobs:
     needs: tag
     uses: ./.github/workflows/_build.yml
     with:
+      electron_version: '39.8.3'
       include_runtime_dependencies: true
-      vsix_version: ${{ github.event.inputs.version }}
+      rebuild_native_modules: true
+      vsix_version: ${{ inputs.version }}
 
   release:
     needs: [tag, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,9 @@ jobs:
     if: "!contains(github.ref_name, '-')"
     uses: ./.github/workflows/_build.yml
     with:
+      electron_version: '39.8.3'
       include_runtime_dependencies: true
+      rebuild_native_modules: true
 
   release:
     needs: build

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,6 @@
 .github/**
+.codex/**
+.claude/**
 .vscode-test/**
 src/**
 test/**
@@ -23,3 +25,4 @@ esbuild.mjs
 yoink.json.schema.json
 ARCHITECTURE.md
 CLAUDE.md
+AGENTS.md

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -34,8 +34,8 @@ if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
     EV=$(python3 -c "import json; print(json.load(open('/Applications/Visual Studio Code.app/Contents/Resources/app/package.json'))['dependencies']['electron'])" 2>/dev/null || echo "39.8.3")
     npx --yes @electron/rebuild -v "$EV" --arch arm64
 
-    # Ensure the arm64 sqlite-vec optional dependency is present
-    npm install --no-save sqlite-vec-darwin-arm64 2>/dev/null || true
+    # Ensure sqlite-vec matches the VS Code host architecture.
+    node scripts/ensure-sqlite-vec-target.mjs --target darwin-arm64
   fi
 fi
 

--- a/scripts/ensure-sqlite-vec-target.mjs
+++ b/scripts/ensure-sqlite-vec-target.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error('Usage: node scripts/ensure-sqlite-vec-target.mjs --target <target>');
+}
+
+function parseTarget(argv) {
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--target') {
+      return argv[i + 1];
+    }
+  }
+  return '';
+}
+
+function packageNameForTarget(target) {
+  switch (target) {
+    case 'darwin-arm64':
+      return 'sqlite-vec-darwin-arm64';
+    case 'darwin-x64':
+      return 'sqlite-vec-darwin-x64';
+    case 'linux-arm64':
+      return 'sqlite-vec-linux-arm64';
+    case 'linux-x64':
+      return 'sqlite-vec-linux-x64';
+    case 'win32-x64':
+      return 'sqlite-vec-windows-x64';
+    default:
+      return '';
+  }
+}
+
+const target = parseTarget(args);
+if (!target) {
+  usage();
+  process.exit(1);
+}
+
+const packageName = packageNameForTarget(target);
+if (!packageName) {
+  console.error(`Unsupported sqlite-vec target: ${target}`);
+  process.exit(1);
+}
+
+const repoRoot = process.cwd();
+const packageJsonPath = path.join(repoRoot, 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const packageLockPath = path.join(repoRoot, 'package-lock.json');
+const packageLock = JSON.parse(fs.readFileSync(packageLockPath, 'utf8'));
+const version =
+  packageJson.optionalDependencies?.[packageName] ??
+  packageJson.dependencies?.[packageName] ??
+  '';
+const resolvedUrl = packageLock.packages?.[`node_modules/${packageName}`]?.resolved ?? '';
+
+const packageDir = path.join(repoRoot, 'node_modules', packageName);
+if (fs.existsSync(packageDir)) {
+  console.log(`sqlite-vec package already present for ${target}: ${packageName}`);
+  process.exit(0);
+}
+
+const spec = version ? `${packageName}@${version}` : packageName;
+const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlite-vec-pack-'));
+try {
+  console.log(`Fetching sqlite-vec package for ${target}: ${spec}`);
+  const packOutput = execFileSync(
+    npmExecutable,
+    ['pack', resolvedUrl || spec, '--pack-destination', tempDir],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    },
+  );
+  const tarballName = packOutput
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .at(-1);
+
+  if (!tarballName) {
+    throw new Error(`Could not determine tarball name for ${spec}`);
+  }
+
+  const tarballPath = path.join(tempDir, tarballName);
+  fs.mkdirSync(packageDir, { recursive: true });
+  execFileSync('tar', ['-xzf', tarballPath, '-C', packageDir, '--strip-components=1'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+  console.log(`Installed sqlite-vec package for ${target}: ${packageName}`);
+} finally {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- add repo-local Codex skills for local VSIX install and isolated VS Code repro loops
- add a target-aware sqlite-vec helper for release/local packaging flows
- keep repo-local Codex resources out of shipped VSIX artifacts

## Testing
- bash -n .codex/skills/yoink-local-vsix-install/scripts/install-vsix.sh
- bash -n .codex/skills/yoink-isolated-vscode-loop/scripts/run-isolated-vscode.sh
- bash .codex/skills/yoink-local-vsix-install/scripts/install-vsix.sh --source local-build --repo-dir /Users/colbyking/source/Lens --skip-npm-ci --prepare-only --yes