### PR TITLE
[codex] add embedding management flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,14 @@
         "title": "Yoink: Sync All Data Sources"
       },
       {
+        "command": "yoink.manageEmbeddings",
+        "title": "Yoink: Manage Embeddings"
+      },
+      {
+        "command": "yoink.rebuildEmbeddings",
+        "title": "Yoink: Rebuild Embeddings"
+      },
+      {
         "command": "yoink.setApiKey",
         "title": "Yoink: Set OpenAI API Key"
       },
@@ -88,6 +96,16 @@
           "command": "yoink.addRepository",
           "when": "view == yoink.dataSources",
           "group": "navigation"
+        },
+        {
+          "command": "yoink.manageEmbeddings",
+          "when": "view == yoink.embedding",
+          "group": "navigation"
+        },
+        {
+          "command": "yoink.rebuildEmbeddings",
+          "when": "view == yoink.embedding",
+          "group": "navigation"
         }
       ],
       "view/item/context": [
@@ -104,6 +122,26 @@
         {
           "command": "yoink.removeDataSourceFromTree",
           "when": "view == yoink.dataSources && viewItem == dataSource",
+          "group": "inline"
+        },
+        {
+          "command": "yoink.manageEmbeddings",
+          "when": "view == yoink.embedding && viewItem == embeddingReady",
+          "group": "inline"
+        },
+        {
+          "command": "yoink.manageEmbeddings",
+          "when": "view == yoink.embedding && viewItem == embeddingNeedsSetup",
+          "group": "inline"
+        },
+        {
+          "command": "yoink.manageEmbeddings",
+          "when": "view == yoink.embedding && viewItem == embeddingStale",
+          "group": "inline"
+        },
+        {
+          "command": "yoink.rebuildEmbeddings",
+          "when": "view == yoink.embedding && viewItem == embeddingStale",
           "group": "inline"
         }
       ]

--- a/src/embedding/manager.ts
+++ b/src/embedding/manager.ts
@@ -1,0 +1,618 @@
+import * as vscode from 'vscode';
+import type Database from 'better-sqlite3';
+import { DataSourceConfig } from '../config/configSchema';
+import { SETTING_KEYS } from '../config/settingsSchema';
+import {
+  EmbeddingConfigurationState,
+  EmbeddingProviderRegistry,
+  EmbeddingProviderType,
+} from './registry';
+import {
+  getEmbeddingConfigFingerprint,
+  getEmbeddingDimensions,
+  resetEmbeddingsTable,
+  setEmbeddingConfigFingerprint,
+} from '../storage/database';
+import { EmbeddingStore } from '../storage/embeddingStore';
+
+interface EmbeddingAssessment {
+  config: EmbeddingConfigurationState;
+  storedFingerprint?: string;
+  storedDimensions: number;
+  hasEmbeddings: boolean;
+  isStale: boolean;
+}
+
+export interface EmbeddingStatus extends EmbeddingConfigurationState {
+  isRebuilding: boolean;
+  isStale: boolean;
+  statusLabel: string;
+  actionCommand: 'yoink.manageEmbeddings' | 'yoink.rebuildEmbeddings';
+  tooltip: string;
+}
+
+interface ManageEmbeddingResult {
+  provider: EmbeddingProviderType;
+  settings: Array<{ key: string; value: string | number }>;
+  secretUpdates: Array<{ kind: 'openai' | 'azure' | 'local'; value?: string }>;
+}
+
+export class EmbeddingManager implements vscode.Disposable {
+  private readonly _onDidChange = new vscode.EventEmitter<void>();
+  readonly onDidChange = this._onDidChange.event;
+
+  private readonly configListener: vscode.Disposable;
+  private readonly secretsListener: vscode.Disposable;
+  private rebuilding = false;
+  private suppressConfigEvents = false;
+  private stalePromptKey?: string;
+
+  constructor(
+    private readonly registry: EmbeddingProviderRegistry,
+    private readonly db: Database.Database,
+    private readonly embeddingStore: EmbeddingStore,
+    private readonly getDataSources: () => readonly DataSourceConfig[],
+    private readonly queueReindexAll: () => Promise<void>,
+    private readonly messagePrefix = 'Yoink',
+  ) {
+    this.configListener = vscode.workspace.onDidChangeConfiguration((event) => {
+      if (this.suppressConfigEvents) return;
+      const isRelevant = this.registry.getManagedSettingKeys()
+        .some((key) => event.affectsConfiguration(key));
+      if (!isRelevant) return;
+      void this.handleConfigurationDrift('settings update');
+    });
+    this.secretsListener = this.registry.onSecretsChanged(() => this.refresh());
+  }
+
+  async initialize(): Promise<void> {
+    await this.handleConfigurationDrift('startup');
+  }
+
+  async ensureConfigured(): Promise<boolean> {
+    const status = await this.getStatus();
+    if (status.isConfigured) {
+      return true;
+    }
+
+    const action = await vscode.window.showErrorMessage(
+      `${this.messagePrefix}: Embeddings are not configured (${status.missingFields.join(', ')}).`,
+      'Manage Embeddings',
+    );
+    if (action === 'Manage Embeddings') {
+      return this.manageEmbeddings();
+    }
+
+    return false;
+  }
+
+  async manageEmbeddings(): Promise<boolean> {
+    const current = await this.registry.getConfigurationState();
+    const choice = await vscode.window.showQuickPick(
+      [
+        {
+          label: 'OpenAI',
+          description: 'Hosted OpenAI embedding API',
+          provider: 'openai' as const,
+        },
+        {
+          label: 'Azure OpenAI',
+          description: 'Azure OpenAI deployment',
+          provider: 'azure-openai' as const,
+        },
+        {
+          label: 'Local',
+          description: 'OpenAI-compatible local server',
+          provider: 'local' as const,
+        },
+      ],
+      {
+        title: 'Yoink: Manage Embeddings',
+        placeHolder: 'Choose an embedding provider',
+        ignoreFocusOut: true,
+      },
+    );
+    if (!choice) return false;
+
+    const result = await this.promptForProvider(choice.provider, current);
+    if (!result) return false;
+
+    const before = await this.assessState();
+    await this.applyManagedConfig(result);
+    const after = await this.assessState();
+
+    this.refresh();
+
+    if (!after.config.isConfigured) {
+      return false;
+    }
+
+    const changed = before.storedFingerprint !== after.config.fingerprint ||
+      before.storedDimensions !== after.config.dimensions;
+    if (!changed) {
+      await this.adoptCurrentFingerprintIfNeeded(after);
+      vscode.window.showInformationMessage(`${this.messagePrefix}: Embedding settings saved.`);
+      return true;
+    }
+
+    await this.rebuildEmbeddings({
+      reason: 'updated embedding settings',
+      skipConfirmation: true,
+      skipManageOnFailure: true,
+    });
+    return true;
+  }
+
+  async rebuildEmbeddings(options?: {
+    reason?: string;
+    skipConfirmation?: boolean;
+    skipManageOnFailure?: boolean;
+  }): Promise<boolean> {
+    if (this.rebuilding) {
+      vscode.window.showInformationMessage(`${this.messagePrefix}: Embedding rebuild already in progress.`);
+      return false;
+    }
+
+    const assessment = await this.assessState();
+    if (!assessment.config.isConfigured || !assessment.config.fingerprint) {
+      if (options?.skipManageOnFailure) {
+        vscode.window.showErrorMessage(
+          `${this.messagePrefix}: Embeddings are not configured (${assessment.config.missingFields.join(', ')}).`,
+        );
+        return false;
+      }
+      return this.ensureConfigured();
+    }
+
+    if (!options?.skipConfirmation) {
+      const action = await vscode.window.showWarningMessage(
+        `${this.messagePrefix}: Rebuild embeddings for all indexed repositories? Existing vectors will be cleared first.`,
+        { modal: true },
+        'Rebuild',
+      );
+      if (action !== 'Rebuild') {
+        return false;
+      }
+    }
+
+    this.rebuilding = true;
+    this.refresh();
+
+    try {
+      resetEmbeddingsTable(this.db, assessment.config.dimensions);
+      this.embeddingStore.refreshAfterSchemaChange();
+      setEmbeddingConfigFingerprint(this.db, assessment.config.fingerprint);
+      this.stalePromptKey = undefined;
+
+      const dataSources = this.getDataSources();
+      if (dataSources.length === 0) {
+        vscode.window.showInformationMessage(`${this.messagePrefix}: Embedding settings saved. No repositories to reindex.`);
+        return true;
+      }
+
+      await this.queueReindexAll();
+      const suffix = options?.reason ? ` after ${options.reason}` : '';
+      vscode.window.showInformationMessage(
+        `${this.messagePrefix}: Rebuilding embeddings for ${dataSources.length} ${dataSources.length === 1 ? 'repository' : 'repositories'}${suffix}.`,
+      );
+      return true;
+    } finally {
+      this.rebuilding = false;
+      this.refresh();
+    }
+  }
+
+  async getStatus(): Promise<EmbeddingStatus> {
+    const assessment = await this.assessState();
+    const lines = [
+      `${assessment.config.providerLabel} ${assessment.config.identifierLabel}: ${assessment.config.identifier}`,
+      `Dimensions: ${assessment.config.dimensions}`,
+    ];
+
+    let statusLabel = 'Configured';
+    let actionCommand: 'yoink.manageEmbeddings' | 'yoink.rebuildEmbeddings' = 'yoink.manageEmbeddings';
+
+    if (this.rebuilding) {
+      statusLabel = 'Rebuilding…';
+      actionCommand = 'yoink.rebuildEmbeddings';
+      lines.push('Status: rebuild in progress');
+    } else if (!assessment.config.isConfigured) {
+      statusLabel = `Setup required: ${assessment.config.missingFields.join(', ')}`;
+      lines.push(`Missing: ${assessment.config.missingFields.join(', ')}`);
+    } else if (assessment.isStale) {
+      statusLabel = 'Rebuild required';
+      actionCommand = 'yoink.rebuildEmbeddings';
+      lines.push('Status: settings changed since the current embeddings were built');
+    } else {
+      lines.push('Status: configured');
+    }
+
+    if (assessment.config.requiresApiKey) {
+      lines.push(`API key: ${assessment.config.hasApiKey ? 'configured' : 'missing'}`);
+    } else if (assessment.config.hasApiKey) {
+      lines.push('API key: configured');
+    }
+
+    return {
+      ...assessment.config,
+      isRebuilding: this.rebuilding,
+      isStale: assessment.isStale,
+      statusLabel,
+      actionCommand,
+      tooltip: lines.join('\n'),
+    };
+  }
+
+  refresh(): void {
+    this._onDidChange.fire();
+  }
+
+  dispose(): void {
+    this.configListener.dispose();
+    this.secretsListener.dispose();
+    this._onDidChange.dispose();
+  }
+
+  private async handleConfigurationDrift(source: string): Promise<void> {
+    const assessment = await this.assessState();
+
+    if (!assessment.config.isConfigured || !assessment.config.fingerprint) {
+      this.refresh();
+      return;
+    }
+
+    if (!assessment.storedFingerprint) {
+      if (!assessment.isStale) {
+        await this.adoptCurrentFingerprintIfNeeded(assessment);
+        this.refresh();
+        return;
+      }
+    }
+
+    if (!assessment.isStale) {
+      this.stalePromptKey = undefined;
+      this.refresh();
+      return;
+    }
+
+    const dataSources = this.getDataSources();
+    if (dataSources.length === 0) {
+      resetEmbeddingsTable(this.db, assessment.config.dimensions);
+      this.embeddingStore.refreshAfterSchemaChange();
+      setEmbeddingConfigFingerprint(this.db, assessment.config.fingerprint);
+      this.refresh();
+      return;
+    }
+
+    const promptKey = `${assessment.storedFingerprint}:${assessment.config.fingerprint}:${assessment.storedDimensions}:${assessment.config.dimensions}`;
+    if (this.stalePromptKey === promptKey) {
+      this.refresh();
+      return;
+    }
+
+    this.stalePromptKey = promptKey;
+    this.refresh();
+
+    const action = await vscode.window.showInformationMessage(
+      `${this.messagePrefix}: Embedding settings changed via ${source}. Rebuild embeddings now?`,
+      'Rebuild',
+      'Later',
+    );
+    if (action === 'Rebuild') {
+      await this.rebuildEmbeddings({
+        reason: source,
+        skipConfirmation: true,
+        skipManageOnFailure: true,
+      });
+    }
+  }
+
+  private async adoptCurrentFingerprintIfNeeded(assessment: EmbeddingAssessment): Promise<void> {
+    if (!assessment.config.fingerprint) return;
+
+    if (!assessment.hasEmbeddings || assessment.storedDimensions === assessment.config.dimensions) {
+      setEmbeddingConfigFingerprint(this.db, assessment.config.fingerprint);
+    }
+  }
+
+  private async assessState(): Promise<EmbeddingAssessment> {
+    const config = await this.registry.getConfigurationState();
+    const storedFingerprint = getEmbeddingConfigFingerprint(this.db);
+    const storedDimensions = getEmbeddingDimensions(this.db);
+    const hasEmbeddings = this.embeddingStore.countAll() > 0;
+    const fingerprintChanged = Boolean(
+      config.isConfigured &&
+      config.fingerprint &&
+      storedFingerprint &&
+      storedFingerprint !== config.fingerprint,
+    );
+    const dimensionChanged = Boolean(
+      config.isConfigured &&
+      hasEmbeddings &&
+      storedDimensions !== config.dimensions,
+    );
+    const isStale = fingerprintChanged || dimensionChanged;
+
+    return {
+      config,
+      storedFingerprint,
+      storedDimensions,
+      hasEmbeddings,
+      isStale,
+    };
+  }
+
+  private async applyManagedConfig(result: ManageEmbeddingResult): Promise<void> {
+    const config = vscode.workspace.getConfiguration();
+
+    this.suppressConfigEvents = true;
+    try {
+      await config.update(SETTING_KEYS.EMBEDDING_PROVIDER, result.provider, vscode.ConfigurationTarget.Global);
+      for (const setting of result.settings) {
+        await config.update(setting.key, setting.value, vscode.ConfigurationTarget.Global);
+      }
+      for (const secret of result.secretUpdates) {
+        await this.applySecret(secret);
+      }
+    } finally {
+      this.suppressConfigEvents = false;
+    }
+  }
+
+  private async applySecret(secret: { kind: 'openai' | 'azure' | 'local'; value?: string }): Promise<void> {
+    if (secret.kind === 'openai') {
+      if (secret.value === undefined) return;
+      await this.registry.setApiKey(secret.value);
+      return;
+    }
+
+    if (secret.kind === 'azure') {
+      if (secret.value === undefined) return;
+      await this.registry.setAzureApiKey(secret.value);
+      return;
+    }
+
+    if (secret.value === undefined) {
+      return;
+    }
+
+    if (secret.value === '') {
+      await this.registry.clearLocalApiKey();
+      return;
+    }
+
+    await this.registry.setLocalApiKey(secret.value);
+  }
+
+  private async promptForProvider(
+    provider: EmbeddingProviderType,
+    current: EmbeddingConfigurationState,
+  ): Promise<ManageEmbeddingResult | undefined> {
+    if (provider === 'azure-openai') {
+      const endpoint = await vscode.window.showInputBox({
+        title: 'Yoink: Azure OpenAI (1/5)',
+        prompt: 'Azure OpenAI endpoint URL',
+        value: current.provider === 'azure-openai'
+          ? (vscode.workspace.getConfiguration().get<string>(SETTING_KEYS.AZURE_ENDPOINT, ''))
+          : '',
+        placeHolder: 'https://myresource.openai.azure.com',
+        ignoreFocusOut: true,
+        validateInput: (value) => value.trim() ? null : 'Endpoint is required',
+      });
+      if (endpoint === undefined) return undefined;
+
+      const deploymentName = await vscode.window.showInputBox({
+        title: 'Yoink: Azure OpenAI (2/5)',
+        prompt: 'Deployment name',
+        value: current.provider === 'azure-openai'
+          ? vscode.workspace.getConfiguration().get<string>(SETTING_KEYS.AZURE_DEPLOYMENT_NAME, '')
+          : '',
+        ignoreFocusOut: true,
+        validateInput: (value) => value.trim() ? null : 'Deployment name is required',
+      });
+      if (deploymentName === undefined) return undefined;
+
+      const apiVersion = await vscode.window.showInputBox({
+        title: 'Yoink: Azure OpenAI (3/5)',
+        prompt: 'API version',
+        value: current.provider === 'azure-openai'
+          ? vscode.workspace.getConfiguration().get<string>(SETTING_KEYS.AZURE_API_VERSION, '2024-02-01')
+          : '2024-02-01',
+        ignoreFocusOut: true,
+        validateInput: (value) => value.trim() ? null : 'API version is required',
+      });
+      if (apiVersion === undefined) return undefined;
+
+      const dimensionsInput = await vscode.window.showInputBox({
+        title: 'Yoink: Azure OpenAI (4/5)',
+        prompt: 'Embedding dimensions',
+        value: String(
+          current.provider === 'azure-openai'
+            ? vscode.workspace.getConfiguration().get<number>(SETTING_KEYS.AZURE_DIMENSIONS, 1536)
+            : 1536,
+        ),
+        ignoreFocusOut: true,
+        validateInput: validatePositiveInteger,
+      });
+      if (dimensionsInput === undefined) return undefined;
+
+      const apiKey = await this.promptRequiredApiKey(
+        'Azure OpenAI',
+        current.provider === 'azure-openai' ? current.hasApiKey : false,
+        'Yoink: Azure OpenAI (5/5)',
+      );
+      if (apiKey === undefined) return undefined;
+
+      return {
+        provider,
+        settings: [
+          { key: SETTING_KEYS.AZURE_ENDPOINT, value: endpoint.trim() },
+          { key: SETTING_KEYS.AZURE_DEPLOYMENT_NAME, value: deploymentName.trim() },
+          { key: SETTING_KEYS.AZURE_API_VERSION, value: apiVersion.trim() },
+          { key: SETTING_KEYS.AZURE_DIMENSIONS, value: parseInt(dimensionsInput, 10) },
+        ],
+        secretUpdates: [{ kind: 'azure', value: apiKey }],
+      };
+    }
+
+    if (provider === 'local') {
+      const baseUrl = await vscode.window.showInputBox({
+        title: 'Yoink: Local Embeddings (1/3)',
+        prompt: 'Local embedding server base URL',
+        value: current.provider === 'local'
+          ? vscode.workspace.getConfiguration().get<string>(SETTING_KEYS.LOCAL_BASE_URL, 'http://localhost:11434/v1')
+          : 'http://localhost:11434/v1',
+        ignoreFocusOut: true,
+        validateInput: (value) => value.trim() ? null : 'Base URL is required',
+      });
+      if (baseUrl === undefined) return undefined;
+
+      const model = await vscode.window.showInputBox({
+        title: 'Yoink: Local Embeddings (2/3)',
+        prompt: 'Model name',
+        value: current.provider === 'local'
+          ? vscode.workspace.getConfiguration().get<string>(SETTING_KEYS.LOCAL_MODEL, '')
+          : '',
+        ignoreFocusOut: true,
+        validateInput: (value) => value.trim() ? null : 'Model is required',
+      });
+      if (model === undefined) return undefined;
+
+      const dimensionsInput = await vscode.window.showInputBox({
+        title: 'Yoink: Local Embeddings (3/3)',
+        prompt: 'Embedding dimensions',
+        value: String(
+          current.provider === 'local'
+            ? vscode.workspace.getConfiguration().get<number>(SETTING_KEYS.LOCAL_DIMENSIONS, 768)
+            : 768,
+        ),
+        ignoreFocusOut: true,
+        validateInput: validatePositiveInteger,
+      });
+      if (dimensionsInput === undefined) return undefined;
+
+      const localApiKey = await this.promptOptionalLocalApiKey(current.provider === 'local' ? current.hasApiKey : false);
+      if (localApiKey === undefined) return undefined;
+
+      return {
+        provider,
+        settings: [
+          { key: SETTING_KEYS.LOCAL_BASE_URL, value: baseUrl.trim() },
+          { key: SETTING_KEYS.LOCAL_MODEL, value: model.trim() },
+          { key: SETTING_KEYS.LOCAL_DIMENSIONS, value: parseInt(dimensionsInput, 10) },
+        ],
+        secretUpdates: [{ kind: 'local', value: localApiKey }],
+      };
+    }
+
+    const model = await vscode.window.showInputBox({
+      title: 'Yoink: OpenAI Embeddings (1/3)',
+      prompt: 'OpenAI model',
+      value: current.provider === 'openai'
+        ? vscode.workspace.getConfiguration().get<string>(SETTING_KEYS.OPENAI_MODEL, 'text-embedding-3-small')
+        : 'text-embedding-3-small',
+      ignoreFocusOut: true,
+      validateInput: (value) => value.trim() ? null : 'Model is required',
+    });
+    if (model === undefined) return undefined;
+
+    const baseUrl = await vscode.window.showInputBox({
+      title: 'Yoink: OpenAI Embeddings (2/3)',
+      prompt: 'OpenAI base URL',
+      value: current.provider === 'openai'
+        ? vscode.workspace.getConfiguration().get<string>(SETTING_KEYS.OPENAI_BASE_URL, 'https://api.openai.com/v1')
+        : 'https://api.openai.com/v1',
+      ignoreFocusOut: true,
+      validateInput: (value) => value.trim() ? null : 'Base URL is required',
+    });
+    if (baseUrl === undefined) return undefined;
+
+    const apiKey = await this.promptRequiredApiKey(
+      'OpenAI',
+      current.provider === 'openai' ? current.hasApiKey : false,
+      'Yoink: OpenAI Embeddings (3/3)',
+    );
+    if (apiKey === undefined) return undefined;
+
+    return {
+      provider,
+      settings: [
+        { key: SETTING_KEYS.OPENAI_MODEL, value: model.trim() },
+        { key: SETTING_KEYS.OPENAI_BASE_URL, value: baseUrl.trim() },
+      ],
+      secretUpdates: [{ kind: 'openai', value: apiKey }],
+    };
+  }
+
+  private async promptRequiredApiKey(
+    providerLabel: string,
+    hasExisting: boolean,
+    title: string,
+  ): Promise<string | undefined> {
+    if (hasExisting) {
+      const action = await vscode.window.showQuickPick<{ label: string; value: 'keep' | 'update' }>(
+        [
+          { label: 'Keep existing API key', value: 'keep' as const },
+          { label: `Update ${providerLabel} API key`, value: 'update' as const },
+        ],
+        {
+          title,
+          placeHolder: `${providerLabel} API key`,
+          ignoreFocusOut: true,
+        },
+      );
+      if (!action) return undefined;
+      if (action.value === 'keep') return undefined;
+    }
+
+    const key = await vscode.window.showInputBox({
+      title,
+      prompt: `Enter your ${providerLabel} API key`,
+      password: true,
+      ignoreFocusOut: true,
+      validateInput: (value) => value.trim() ? null : 'API key cannot be empty',
+    });
+    if (!key) return undefined;
+    return key.trim();
+  }
+
+  private async promptOptionalLocalApiKey(hasExisting: boolean): Promise<string | undefined> {
+    const actionItems: Array<{ label: string; value: 'keep' | 'update' | 'clear' | 'none' }> = hasExisting
+        ? [
+          { label: 'Keep existing API key', value: 'keep' as const },
+          { label: 'Set a new API key', value: 'update' as const },
+          { label: 'Remove API key', value: 'clear' as const },
+        ]
+        : [
+          { label: 'No API key', value: 'none' as const },
+          { label: 'Set API key', value: 'update' as const },
+        ];
+
+    const action = await vscode.window.showQuickPick(
+      actionItems,
+      {
+        title: 'Yoink: Local Embeddings (API Key)',
+        placeHolder: 'Optional local API key',
+        ignoreFocusOut: true,
+      },
+    );
+    if (!action) return undefined;
+    if (action.value === 'keep' || action.value === 'none') return undefined;
+    if (action.value === 'clear') return '';
+
+    const key = await vscode.window.showInputBox({
+      title: 'Yoink: Local Embeddings (API Key)',
+      prompt: 'Enter the local embedding API key',
+      password: true,
+      ignoreFocusOut: true,
+      validateInput: (value) => value.trim() ? null : 'API key cannot be empty',
+    });
+    if (!key) return undefined;
+    return key.trim();
+  }
+}
+
+function validatePositiveInteger(value: string): string | null {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? null : 'Enter a positive integer';
+}

--- a/src/embedding/registry.ts
+++ b/src/embedding/registry.ts
@@ -4,13 +4,35 @@ import { OpenAIEmbeddingProvider } from './openaiProvider';
 import { AzureOpenAIEmbeddingProvider } from './azureOpenAIProvider';
 import { LocalEmbeddingProvider } from './localProvider';
 import { SETTING_KEYS } from '../config/settingsSchema';
+import { createHash } from 'node:crypto';
+
+export type EmbeddingProviderType = 'openai' | 'azure-openai' | 'local';
+
+export interface EmbeddingConfigurationState {
+  provider: EmbeddingProviderType;
+  providerLabel: string;
+  identifier: string;
+  identifierLabel: string;
+  dimensions: number;
+  requiresApiKey: boolean;
+  hasApiKey: boolean;
+  missingFields: string[];
+  isConfigured: boolean;
+  fingerprint?: string;
+}
+
+const OPENAI_MODEL_DIMENSIONS: Record<string, number> = {
+  'text-embedding-3-small': 1536,
+  'text-embedding-3-large': 3072,
+  'text-embedding-ada-002': 1536,
+};
 
 export class EmbeddingProviderRegistry {
   constructor(private readonly secretStorage: vscode.SecretStorage) {}
 
   async getProvider(): Promise<EmbeddingProvider> {
     const config = vscode.workspace.getConfiguration();
-    const providerType = config.get<string>(SETTING_KEYS.EMBEDDING_PROVIDER, 'openai');
+    const providerType = this.getProviderType(config);
 
     switch (providerType) {
       case 'openai':
@@ -22,6 +44,135 @@ export class EmbeddingProviderRegistry {
       default:
         throw new Error(`Unknown embedding provider: ${providerType}`);
     }
+  }
+
+  getProviderType(
+    config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(),
+  ): EmbeddingProviderType {
+    return config.get<EmbeddingProviderType>(SETTING_KEYS.EMBEDDING_PROVIDER, 'openai');
+  }
+
+  async getConfigurationState(
+    config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(),
+  ): Promise<EmbeddingConfigurationState> {
+    const provider = this.getProviderType(config);
+
+    if (provider === 'azure-openai') {
+      const endpoint = config.get<string>(SETTING_KEYS.AZURE_ENDPOINT, '').trim();
+      const deploymentName = config.get<string>(SETTING_KEYS.AZURE_DEPLOYMENT_NAME, '').trim();
+      const apiVersion = config.get<string>(SETTING_KEYS.AZURE_API_VERSION, '2024-02-01').trim();
+      const dimensions = config.get<number>(SETTING_KEYS.AZURE_DIMENSIONS, 1536);
+      const hasApiKey = await this.hasAzureApiKey();
+      const missingFields = [
+        ...(endpoint ? [] : ['endpoint']),
+        ...(deploymentName ? [] : ['deployment name']),
+        ...(apiVersion ? [] : ['API version']),
+        ...(Number.isFinite(dimensions) && dimensions > 0 ? [] : ['dimensions']),
+        ...(hasApiKey ? [] : ['API key']),
+      ];
+
+      return {
+        provider,
+        providerLabel: 'Azure OpenAI',
+        identifier: deploymentName || 'Azure OpenAI',
+        identifierLabel: 'Deployment',
+        dimensions,
+        requiresApiKey: true,
+        hasApiKey,
+        missingFields,
+        isConfigured: missingFields.length === 0,
+        fingerprint: endpoint && deploymentName && apiVersion && dimensions > 0
+          ? this.fingerprintFor({
+            provider,
+            endpoint,
+            deploymentName,
+            apiVersion,
+            dimensions,
+          })
+          : undefined,
+      };
+    }
+
+    if (provider === 'local') {
+      const baseUrl = config.get<string>(SETTING_KEYS.LOCAL_BASE_URL, 'http://localhost:11434/v1').trim();
+      const model = config.get<string>(SETTING_KEYS.LOCAL_MODEL, '').trim();
+      const dimensions = config.get<number>(SETTING_KEYS.LOCAL_DIMENSIONS, 768);
+      const hasApiKey = await this.hasLocalApiKey();
+      const missingFields = [
+        ...(baseUrl ? [] : ['base URL']),
+        ...(model ? [] : ['model']),
+        ...(Number.isFinite(dimensions) && dimensions > 0 ? [] : ['dimensions']),
+      ];
+
+      return {
+        provider,
+        providerLabel: 'Local',
+        identifier: model || 'Local model',
+        identifierLabel: 'Model',
+        dimensions,
+        requiresApiKey: false,
+        hasApiKey,
+        missingFields,
+        isConfigured: missingFields.length === 0,
+        fingerprint: baseUrl && model && dimensions > 0
+          ? this.fingerprintFor({
+            provider,
+            baseUrl,
+            model,
+            dimensions,
+          })
+          : undefined,
+      };
+    }
+
+    const model = config.get<string>(SETTING_KEYS.OPENAI_MODEL, 'text-embedding-3-small').trim();
+    const baseUrl = config.get<string>(SETTING_KEYS.OPENAI_BASE_URL, 'https://api.openai.com/v1').trim();
+    const dimensions = getOpenAIModelDimensions(model);
+    const hasApiKey = await this.hasApiKey();
+    const missingFields = [
+      ...(model ? [] : ['model']),
+      ...(baseUrl ? [] : ['base URL']),
+      ...(hasApiKey ? [] : ['API key']),
+    ];
+
+    return {
+      provider,
+      providerLabel: 'OpenAI',
+      identifier: model || 'OpenAI',
+      identifierLabel: 'Model',
+      dimensions,
+      requiresApiKey: true,
+      hasApiKey,
+      missingFields,
+      isConfigured: missingFields.length === 0,
+      fingerprint: model && baseUrl
+        ? this.fingerprintFor({
+          provider,
+          model,
+          baseUrl,
+          dimensions,
+        })
+        : undefined,
+    };
+  }
+
+  getManagedSettingKeys(): string[] {
+    return [
+      SETTING_KEYS.EMBEDDING_PROVIDER,
+      SETTING_KEYS.OPENAI_MODEL,
+      SETTING_KEYS.OPENAI_BASE_URL,
+      SETTING_KEYS.AZURE_ENDPOINT,
+      SETTING_KEYS.AZURE_DEPLOYMENT_NAME,
+      SETTING_KEYS.AZURE_API_VERSION,
+      SETTING_KEYS.AZURE_DIMENSIONS,
+      SETTING_KEYS.LOCAL_BASE_URL,
+      SETTING_KEYS.LOCAL_MODEL,
+      SETTING_KEYS.LOCAL_DIMENSIONS,
+    ];
+  }
+
+  onSecretsChanged(listener: () => void): vscode.Disposable {
+    return this.secretStorage.onDidChange(() => listener());
   }
 
   // ── OpenAI ────────────────────────────────────────────────────────────────
@@ -145,4 +296,27 @@ export class EmbeddingProviderRegistry {
       apiKey: apiKey || undefined,
     });
   }
+
+  async hasLocalApiKey(): Promise<boolean> {
+    const stored = await this.secretStorage.get('yoink.local.apiKey');
+    return Boolean(stored ?? process.env.LOCAL_EMBEDDING_API_KEY);
+  }
+
+  async setLocalApiKey(key: string): Promise<void> {
+    await this.secretStorage.store('yoink.local.apiKey', key);
+  }
+
+  async clearLocalApiKey(): Promise<void> {
+    await this.secretStorage.delete('yoink.local.apiKey');
+  }
+
+  private fingerprintFor(payload: Record<string, string | number>): string {
+    return createHash('sha256')
+      .update(JSON.stringify(payload))
+      .digest('hex');
+  }
+}
+
+export function getOpenAIModelDimensions(model: string): number {
+  return OPENAI_MODEL_DIMENSIONS[model] ?? 1536;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import { WorkspaceConfigManager } from './config/workspaceConfig';
 import { DeltaSync } from './sources/sync/deltaSync';
 import { Logger } from './util/logger';
 import { AgentInstaller } from './agents/agentInstaller';
+import { EmbeddingManager } from './embedding/manager';
 
 export function activate(context: vscode.ExtensionContext): void {
   const logger = new Logger();
@@ -86,7 +87,16 @@ export function activate(context: vscode.ExtensionContext): void {
   });
 
   // Data source management
-  const dataSourceManager = new DataSourceManager(configManager, pipeline, providerRegistry);
+  const dataSourceManagerRef: { current?: DataSourceManager } = {};
+  const embeddingManager = new EmbeddingManager(
+    providerRegistry,
+    db,
+    embeddingStore,
+    () => configManager.getDataSources(),
+    () => dataSourceManagerRef.current!.syncAll(),
+  );
+  const dataSourceManager = new DataSourceManager(configManager, pipeline, embeddingManager);
+  dataSourceManagerRef.current = dataSourceManager;
 
   // Retrieval
   const retriever = new Retriever(chunkStore, embeddingStore);
@@ -106,7 +116,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // Sidebar
   const dataSourceTreeProvider = new DataSourceTreeProvider(configManager, chunkStore, progressTracker);
-  const embeddingTreeProvider = new EmbeddingTreeProvider(providerRegistry, context.secrets);
+  const embeddingTreeProvider = new EmbeddingTreeProvider(embeddingManager);
   vscode.window.registerTreeDataProvider('yoink.dataSources', dataSourceTreeProvider);
   vscode.window.registerTreeDataProvider('yoink.embedding', embeddingTreeProvider);
 
@@ -125,8 +135,9 @@ export function activate(context: vscode.ExtensionContext): void {
     context,
     configManager,
     dataSourceManager,
+    embeddingManager,
     providerRegistry,
-    () => new AddRepoWizard(resolver, browser, dataSourceManager, providerRegistry),
+    () => new AddRepoWizard(resolver, browser, dataSourceManager, embeddingManager),
     workspaceConfigManager,
     agentInstaller,
   );
@@ -143,12 +154,15 @@ export function activate(context: vscode.ExtensionContext): void {
     toolManager,
     scheduler,
     embeddingTreeProvider,
+    embeddingManager,
     progressTracker,
     logger,
   );
 
   // Detect workspace config and prompt import
   workspaceConfigManager.detectAndPrompt();
+
+  void embeddingManager.initialize();
 
   // Silently install Copilot agent files on first activation
   const primaryFolder = vscode.workspace.workspaceFolders?.[0];

--- a/src/sources/dataSourceManager.ts
+++ b/src/sources/dataSourceManager.ts
@@ -4,7 +4,7 @@ import { ConfigManager } from '../config/configManager';
 import { DataSourceConfig } from '../config/configSchema';
 import { DataSourceType } from '../config/repoTypePresets';
 import { IngestionPipeline } from '../ingestion/pipeline';
-import { EmbeddingProviderRegistry } from '../embedding/registry';
+import { EmbeddingManager } from '../embedding/manager';
 
 export interface AddDataSourceOptions {
   repoUrl: string;
@@ -23,7 +23,7 @@ export class DataSourceManager implements vscode.Disposable {
   constructor(
     private readonly configManager: ConfigManager,
     private readonly pipeline: IngestionPipeline,
-    private readonly embeddingRegistry: EmbeddingProviderRegistry,
+    private readonly embeddingManager: EmbeddingManager,
   ) {}
 
   /**
@@ -66,18 +66,9 @@ export class DataSourceManager implements vscode.Disposable {
   }
 
   private async assertApiKeyConfigured(): Promise<void> {
-    try {
-      await this.embeddingRegistry.getProvider();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const action = await vscode.window.showErrorMessage(
-        `Yoink: ${message}`,
-        'Set API Key',
-      );
-      if (action === 'Set API Key') {
-        await vscode.commands.executeCommand('yoink.setApiKey');
-      }
-      throw err;
+    const ready = await this.embeddingManager.ensureConfigured();
+    if (!ready) {
+      throw new Error('Embedding provider is not configured.');
     }
   }
 

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -5,6 +5,9 @@ import * as fs from 'fs';
 
 const SCHEMA_VERSION = 3;
 const DEFAULT_DIMENSIONS = 1536;
+const META_EMBEDDING_DIMENSIONS = 'embedding_dimensions';
+const META_EMBEDDING_CONFIG_FINGERPRINT = 'embedding_config_fingerprint';
+const META_SCHEMA_VERSION = 'schema_version';
 
 export interface OpenDatabaseOptions {
   /** Directory to store the DB file. If omitted, uses an in-memory DB. */
@@ -56,7 +59,7 @@ function migrate(db: Database.Database, dimensions: number): void {
     );
 
     db.prepare(
-      "INSERT OR REPLACE INTO meta (key, value) VALUES ('embedding_dimensions', ?)",
+      `INSERT OR REPLACE INTO meta (key, value) VALUES ('${META_EMBEDDING_DIMENSIONS}', ?)`,
     ).run(dimensions.toString());
   }
 
@@ -128,9 +131,7 @@ function migrate(db: Database.Database, dimensions: number): void {
 
 function getSchemaVersion(db: Database.Database): number {
   try {
-    const row = db.prepare("SELECT value FROM meta WHERE key = 'schema_version'").get() as
-      | { value: string }
-      | undefined;
+    const row = getMetaValue(db, META_SCHEMA_VERSION);
     return row ? parseInt(row.value, 10) : 0;
   } catch {
     return 0;
@@ -139,15 +140,24 @@ function getSchemaVersion(db: Database.Database): number {
 
 function setSchemaVersion(db: Database.Database, version: number): void {
   db.prepare(
-    "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', ?)",
+    `INSERT OR REPLACE INTO meta (key, value) VALUES ('${META_SCHEMA_VERSION}', ?)`,
   ).run(version.toString());
 }
 
 export function getEmbeddingDimensions(db: Database.Database): number {
-  const row = db.prepare(
-    "SELECT value FROM meta WHERE key = 'embedding_dimensions'",
-  ).get() as { value: string } | undefined;
+  const row = getMetaValue(db, META_EMBEDDING_DIMENSIONS);
   return row ? parseInt(row.value, 10) : DEFAULT_DIMENSIONS;
+}
+
+export function getEmbeddingConfigFingerprint(db: Database.Database): string | undefined {
+  return getMetaValue(db, META_EMBEDDING_CONFIG_FINGERPRINT)?.value;
+}
+
+export function setEmbeddingConfigFingerprint(
+  db: Database.Database,
+  fingerprint: string,
+): void {
+  setMetaValue(db, META_EMBEDDING_CONFIG_FINGERPRINT, fingerprint);
 }
 
 /**
@@ -162,7 +172,26 @@ export function recreateEmbeddingsTable(db: Database.Database, dimensions: numbe
       embedding FLOAT[${dimensions}]
     )`,
   );
+  setMetaValue(db, META_EMBEDDING_DIMENSIONS, dimensions.toString());
+}
+
+export function resetEmbeddingsTable(db: Database.Database, dimensions: number): void {
+  if (getEmbeddingDimensions(db) === dimensions) {
+    db.exec('DELETE FROM embeddings');
+    return;
+  }
+
+  recreateEmbeddingsTable(db, dimensions);
+}
+
+function getMetaValue(db: Database.Database, key: string): { value: string } | undefined {
+  return db.prepare(
+    'SELECT value FROM meta WHERE key = ?',
+  ).get(key) as { value: string } | undefined;
+}
+
+function setMetaValue(db: Database.Database, key: string, value: string): void {
   db.prepare(
-    "INSERT OR REPLACE INTO meta (key, value) VALUES ('embedding_dimensions', ?)",
-  ).run(dimensions.toString());
+    'INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)',
+  ).run(key, value);
 }

--- a/src/storage/embeddingStore.ts
+++ b/src/storage/embeddingStore.ts
@@ -15,16 +15,28 @@ function toVecBlob(embedding: number[]): Buffer {
 }
 
 export class EmbeddingStore {
-  private readonly insertStmt: Database.Statement;
-  private readonly deleteStmt: Database.Statement;
-  private readonly searchAllStmt: Database.Statement;
+  private insertStmt!: Database.Statement;
+  private deleteStmt!: Database.Statement;
+  private clearStmt!: Database.Statement;
+  private countStmt!: Database.Statement;
+  private searchAllStmt!: Database.Statement;
 
   constructor(private readonly db: Database.Database) {
-    this.insertStmt = db.prepare(
+    this.prepareStatements();
+  }
+
+  refreshAfterSchemaChange(): void {
+    this.prepareStatements();
+  }
+
+  private prepareStatements(): void {
+    this.insertStmt = this.db.prepare(
       'INSERT INTO embeddings (chunk_id, embedding) VALUES (?, ?)',
     );
-    this.deleteStmt = db.prepare('DELETE FROM embeddings WHERE chunk_id = ?');
-    this.searchAllStmt = db.prepare(`
+    this.deleteStmt = this.db.prepare('DELETE FROM embeddings WHERE chunk_id = ?');
+    this.clearStmt = this.db.prepare('DELETE FROM embeddings');
+    this.countStmt = this.db.prepare('SELECT COUNT(*) as count FROM embeddings');
+    this.searchAllStmt = this.db.prepare(`
       SELECT chunk_id, distance
       FROM embeddings
       WHERE embedding MATCH ?
@@ -54,6 +66,15 @@ export class EmbeddingStore {
       }
     });
     tx(chunkIds);
+  }
+
+  clearAll(): void {
+    this.clearStmt.run();
+  }
+
+  countAll(): number {
+    const row = this.countStmt.get() as { count: number };
+    return row.count;
   }
 
   /**

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -6,11 +6,13 @@ import { ConfigManager } from '../config/configManager';
 import { WorkspaceConfigManager } from '../config/workspaceConfig';
 import { DataSourceTreeItem } from './sidebar/sidebarTreeItems';
 import { AgentInstaller } from '../agents/agentInstaller';
+import { EmbeddingManager } from '../embedding/manager';
 
 export function registerCommands(
   context: vscode.ExtensionContext,
   configManager: ConfigManager,
   dataSourceManager: DataSourceManager,
+  embeddingManager: EmbeddingManager,
   providerRegistry: EmbeddingProviderRegistry,
   wizardFactory: () => AddRepoWizard,
   workspaceConfigManager: WorkspaceConfigManager,
@@ -20,6 +22,14 @@ export function registerCommands(
     vscode.commands.registerCommand('yoink.addRepository', async () => {
       const wizard = wizardFactory();
       await wizard.run();
+    }),
+
+    vscode.commands.registerCommand('yoink.manageEmbeddings', async () => {
+      await embeddingManager.manageEmbeddings();
+    }),
+
+    vscode.commands.registerCommand('yoink.rebuildEmbeddings', async () => {
+      await embeddingManager.rebuildEmbeddings();
     }),
 
     vscode.commands.registerCommand('yoink.removeRepository', async () => {
@@ -76,6 +86,7 @@ export function registerCommands(
       });
       if (key) {
         await providerRegistry.setApiKey(key);
+        embeddingManager.refresh();
         vscode.window.showInformationMessage('OpenAI API key saved.');
       }
     }),
@@ -88,6 +99,7 @@ export function registerCommands(
       });
       if (key) {
         await providerRegistry.setAzureApiKey(key);
+        embeddingManager.refresh();
         vscode.window.showInformationMessage('Azure OpenAI API key saved.');
       }
     }),
@@ -131,11 +143,9 @@ export function registerCommands(
         { label: 'On Startup', description: 'Sync when VS Code starts', value: 'onStartup' as const },
         { label: 'Daily', description: 'Sync once per day', value: 'daily' as const },
       ];
-      const currentIdx = scheduleItems.findIndex((s) => s.value === ds.syncSchedule);
-      const schedulePick = await vscode.window.showQuickPick(scheduleItems, {
+      const schedulePick = await vscode.window.showQuickPick<(typeof scheduleItems)[number]>(scheduleItems, {
         title: `Edit ${repoLabel} (2/3)`,
         placeHolder: 'Sync schedule',
-        activeItems: currentIdx >= 0 ? [scheduleItems[currentIdx]] : [],
         ignoreFocusOut: true,
       });
       if (!schedulePick) return;

--- a/src/ui/sidebar/sidebarProvider.ts
+++ b/src/ui/sidebar/sidebarProvider.ts
@@ -7,10 +7,10 @@ import {
   DataSourceFileItem,
   EmbeddingTreeItem,
 } from './sidebarTreeItems';
-import { EmbeddingProviderRegistry } from '../../embedding/registry';
 import { SETTING_KEYS } from '../../config/settingsSchema';
 import { ChunkStore } from '../../storage/chunkStore';
 import { ProgressTracker } from '../../ingestion/progressTracker';
+import { EmbeddingManager } from '../../embedding/manager';
 
 export class DataSourceTreeProvider
   implements vscode.TreeDataProvider<SidebarTreeItem>
@@ -63,13 +63,12 @@ export class DataSourceTreeProvider
 export class EmbeddingTreeProvider implements vscode.TreeDataProvider<SidebarTreeItem>, vscode.Disposable {
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<SidebarTreeItem | undefined>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
-  private readonly secretsListener: vscode.Disposable;
+  private readonly managerListener: vscode.Disposable;
 
   constructor(
-    private readonly embeddingRegistry: EmbeddingProviderRegistry,
-    secrets: vscode.SecretStorage,
+    private readonly embeddingManager: EmbeddingManager,
   ) {
-    this.secretsListener = secrets.onDidChange(() => this.refresh());
+    this.managerListener = embeddingManager.onDidChange(() => this.refresh());
   }
 
   refresh(): void {
@@ -81,26 +80,11 @@ export class EmbeddingTreeProvider implements vscode.TreeDataProvider<SidebarTre
   }
 
   async getChildren(): Promise<SidebarTreeItem[]> {
-    const config = vscode.workspace.getConfiguration();
-    const providerType = config.get<string>(SETTING_KEYS.EMBEDDING_PROVIDER, 'openai');
-
-    if (providerType === 'azure-openai') {
-      const deployment = config.get<string>(SETTING_KEYS.AZURE_DEPLOYMENT_NAME, '');
-      const hasKey = await this.embeddingRegistry.hasAzureApiKey();
-      return [new EmbeddingTreeItem(deployment || 'Azure OpenAI', hasKey, 'azure-openai')];
-    } else if (providerType === 'local') {
-      const model = config.get<string>(SETTING_KEYS.LOCAL_MODEL, 'local');
-      return [new EmbeddingTreeItem(model, true, 'local')];
-    } else {
-      const model = config.get<string>(SETTING_KEYS.OPENAI_MODEL, 'text-embedding-3-small');
-      const hasKey = await this.embeddingRegistry.hasApiKey();
-      return [new EmbeddingTreeItem(model, hasKey, 'openai')];
-    }
+    return [new EmbeddingTreeItem(await this.embeddingManager.getStatus())];
   }
 
   dispose(): void {
-    this.secretsListener.dispose();
+    this.managerListener.dispose();
     this._onDidChangeTreeData.dispose();
   }
 }
-

--- a/src/ui/sidebar/sidebarTreeItems.ts
+++ b/src/ui/sidebar/sidebarTreeItems.ts
@@ -3,6 +3,7 @@ import { DataSourceConfig } from '../../config/configSchema';
 import { DataSourceStats, FileStats } from '../../storage/chunkStore';
 import { IndexingProgress } from '../../ingestion/progressTracker';
 import { getPricingForModel, formatCost } from '../../embedding/pricing';
+import { EmbeddingStatus } from '../../embedding/manager';
 
 export type SidebarTreeItem =
   | DataSourceTreeItem
@@ -115,29 +116,32 @@ export class DataSourceFileItem extends vscode.TreeItem {
 }
 
 export class EmbeddingTreeItem extends vscode.TreeItem {
-  constructor(model: string, hasKey: boolean, provider: 'openai' | 'azure-openai' | 'local') {
-    super(model, vscode.TreeItemCollapsibleState.None);
+  constructor(status: EmbeddingStatus) {
+    super(`${status.providerLabel}: ${status.identifier}`, vscode.TreeItemCollapsibleState.None);
 
-    if (provider === 'local') {
-      this.description = '$(check) Local model';
-      this.iconPath = new vscode.ThemeIcon('symbol-misc');
-      this.tooltip = `Embedding model: ${model}\nLocal model (no API key required)`;
-    } else if (hasKey) {
-      this.description = '$(check) API key configured';
-      this.iconPath = new vscode.ThemeIcon('symbol-misc');
-      this.tooltip = `Embedding model: ${model}\nAPI key: configured`;
+    this.description = status.isRebuilding
+      ? '$(sync~spin) Rebuilding…'
+      : status.isStale
+        ? '$(warning) Rebuild required'
+        : status.isConfigured
+          ? '$(check) Configured'
+          : '$(warning) Setup required';
+    this.tooltip = status.tooltip;
+    this.contextValue = status.isStale ? 'embeddingStale' : (status.isConfigured ? 'embeddingReady' : 'embeddingNeedsSetup');
+    this.command = {
+      command: status.actionCommand,
+      title: status.actionCommand === 'yoink.rebuildEmbeddings' ? 'Rebuild Embeddings' : 'Manage Embeddings',
+    };
+
+    if (status.isRebuilding) {
+      this.iconPath = new vscode.ThemeIcon('loading~spin');
+    } else if (status.isStale || !status.isConfigured) {
+      this.iconPath = new vscode.ThemeIcon(
+        'warning',
+        new vscode.ThemeColor('problemsWarningIcon.foreground'),
+      );
     } else {
-      const setKeyCommand = provider === 'azure-openai' ? 'yoink.setAzureApiKey' : 'yoink.setApiKey';
-      const providerLabel = provider === 'azure-openai' ? 'Azure OpenAI' : 'OpenAI';
-      this.description = '$(warning) No API key — click to set';
-      this.iconPath = new vscode.ThemeIcon('warning', new vscode.ThemeColor('problemsWarningIcon.foreground'));
-      this.tooltip = `Embedding model: ${model}\nAPI key: not configured\nClick to set your ${providerLabel} API key`;
-      this.command = {
-        command: setKeyCommand,
-        title: 'Set API Key',
-      };
+      this.iconPath = new vscode.ThemeIcon('symbol-misc');
     }
-    this.contextValue = 'embedding';
   }
 }
-

--- a/src/ui/wizard/addRepoWizard.ts
+++ b/src/ui/wizard/addRepoWizard.ts
@@ -4,29 +4,20 @@ import { RepoBrowser } from '../../sources/github/repoBrowser';
 import { DataSourceManager, AddDataSourceOptions } from '../../sources/dataSourceManager';
 import { DEFAULT_EXCLUDE_PATTERNS } from '../../config/configSchema';
 import { REPO_TYPE_PRESETS } from '../../config/repoTypePresets';
-import { EmbeddingProviderRegistry } from '../../embedding/registry';
+import { EmbeddingManager } from '../../embedding/manager';
 
 export class AddRepoWizard {
   constructor(
     private readonly resolver: GitHubResolver,
     private readonly browser: RepoBrowser,
     private readonly dataSourceManager: DataSourceManager,
-    private readonly embeddingRegistry: EmbeddingProviderRegistry,
+    private readonly embeddingManager: EmbeddingManager,
   ) {}
 
   async run(): Promise<void> {
-    // Step 0: Ensure API key is configured
-    if (!(await this.embeddingRegistry.hasApiKey())) {
-      const apiKey = await vscode.window.showInputBox({
-        title: 'Yoink: OpenAI API Key Required',
-        prompt: 'Enter your OpenAI API key to enable embeddings',
-        placeHolder: 'sk-...',
-        password: true,
-        ignoreFocusOut: true,
-        validateInput: (v) => v.trim() ? null : 'API key cannot be empty',
-      });
-      if (!apiKey) return;
-      await this.embeddingRegistry.setApiKey(apiKey.trim());
+    // Step 0: Ensure embeddings are configured
+    if (!(await this.embeddingManager.ensureConfigured())) {
+      return;
     }
 
     // Step 1: Get repo URL or search
@@ -85,9 +76,8 @@ export class AddRepoWizard {
       { label: 'On Startup', value: 'onStartup' as const },
       { label: 'Daily', value: 'daily' as const },
     ];
-    const schedule = await vscode.window.showQuickPick(scheduleItems, {
+    const schedule = await vscode.window.showQuickPick<(typeof scheduleItems)[number]>(scheduleItems, {
       placeHolder: 'Sync schedule',
-      activeItems: [scheduleItems[0]],
       ignoreFocusOut: true,
     });
     if (!schedule) return;
@@ -111,7 +101,7 @@ export class AddRepoWizard {
   }
 
   private async getRepoInput(): Promise<{ owner: string; repo: string } | undefined> {
-    const choice = await vscode.window.showQuickPick(
+    const choice = await vscode.window.showQuickPick<{ label: string; value: 'url' | 'browse' }>(
       [
         { label: '$(link) Paste Repository URL', value: 'url' },
         { label: '$(search) Browse My Repositories', value: 'browse' },

--- a/test/unit/embedding/manager.test.ts
+++ b/test/unit/embedding/manager.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  configListeners,
+  configuration,
+  showQuickPick,
+  showInputBox,
+  showInformationMessage,
+  showWarningMessage,
+  showErrorMessage,
+  getEmbeddingConfigFingerprint,
+  getEmbeddingDimensions,
+  resetEmbeddingsTable,
+  setEmbeddingConfigFingerprint,
+  getConfigValues,
+  setConfigValues,
+} = vi.hoisted(() => {
+  let configValues = new Map<string, string | number>();
+  const configuration = {
+    get: vi.fn((key: string, defaultValue?: string | number) => (
+      configValues.has(key) ? configValues.get(key) : defaultValue
+    )),
+    update: vi.fn(async (key: string, value: string | number) => {
+      configValues.set(key, value);
+    }),
+  };
+
+  return {
+    configListeners: [] as Array<(event: { affectsConfiguration: (key: string) => boolean }) => void>,
+    configuration,
+    showQuickPick: vi.fn(),
+    showInputBox: vi.fn(),
+    showInformationMessage: vi.fn(),
+    showWarningMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+    getEmbeddingConfigFingerprint: vi.fn(),
+    getEmbeddingDimensions: vi.fn(),
+    resetEmbeddingsTable: vi.fn(),
+    setEmbeddingConfigFingerprint: vi.fn(),
+    getConfigValues: () => configValues,
+    setConfigValues: (next: Map<string, string | number>) => {
+      configValues = next;
+    },
+  };
+});
+
+vi.mock('vscode', () => ({
+  ConfigurationTarget: { Global: 1 },
+  workspace: {
+    getConfiguration: () => configuration,
+    onDidChangeConfiguration: (listener: (event: { affectsConfiguration: (key: string) => boolean }) => void) => {
+      configListeners.push(listener);
+      return { dispose: vi.fn() };
+    },
+  },
+  window: {
+    showQuickPick,
+    showInputBox,
+    showInformationMessage,
+    showWarningMessage,
+    showErrorMessage,
+  },
+  EventEmitter: class<T> {
+    private listeners: Array<(event: T | undefined) => void> = [];
+
+    event = (listener: (event: T | undefined) => void) => {
+      this.listeners.push(listener);
+      return { dispose: vi.fn() };
+    };
+
+    fire(event?: T) {
+      this.listeners.forEach((listener) => listener(event));
+    }
+
+    dispose() {}
+  },
+}));
+
+vi.mock('../../../src/storage/database', () => ({
+  getEmbeddingConfigFingerprint,
+  getEmbeddingDimensions,
+  resetEmbeddingsTable,
+  setEmbeddingConfigFingerprint,
+}));
+
+import { EmbeddingManager } from '../../../src/embedding/manager';
+
+describe('EmbeddingManager', () => {
+  let registry: any;
+  let embeddingStore: any;
+  let getDataSources: any;
+  let queueReindexAll: any;
+  let hasOpenAIKey: boolean;
+  let hasAzureKey: boolean;
+  let hasLocalKey: boolean;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configListeners.length = 0;
+    setConfigValues(new Map<string, string | number>([
+      ['yoink.embedding.provider', 'openai'],
+      ['yoink.embedding.openai.model', 'text-embedding-3-small'],
+      ['yoink.embedding.openai.baseUrl', 'https://api.openai.com/v1'],
+      ['yoink.embedding.azure.endpoint', 'https://azure.example.com'],
+      ['yoink.embedding.azure.deploymentName', 'embed-prod'],
+      ['yoink.embedding.azure.apiVersion', '2024-02-01'],
+      ['yoink.embedding.azure.dimensions', 3072],
+      ['yoink.embedding.local.baseUrl', 'http://localhost:11434/v1'],
+      ['yoink.embedding.local.model', 'nomic-embed-text'],
+      ['yoink.embedding.local.dimensions', 768],
+    ]));
+
+    hasOpenAIKey = true;
+    hasAzureKey = false;
+    hasLocalKey = false;
+
+    registry = {
+      getManagedSettingKeys: vi.fn().mockReturnValue([
+        'yoink.embedding.provider',
+        'yoink.embedding.openai.model',
+        'yoink.embedding.openai.baseUrl',
+        'yoink.embedding.azure.endpoint',
+        'yoink.embedding.azure.deploymentName',
+        'yoink.embedding.azure.apiVersion',
+        'yoink.embedding.azure.dimensions',
+        'yoink.embedding.local.baseUrl',
+        'yoink.embedding.local.model',
+        'yoink.embedding.local.dimensions',
+      ]),
+      onSecretsChanged: vi.fn().mockImplementation((listener: () => void) => {
+        return { dispose: vi.fn(), listener };
+      }),
+      getConfigurationState: vi.fn().mockImplementation(async () => {
+        const provider = configuration.get('yoink.embedding.provider', 'openai');
+        if (provider === 'azure-openai') {
+          return {
+            provider,
+            providerLabel: 'Azure OpenAI',
+            identifier: String(configuration.get('yoink.embedding.azure.deploymentName', 'Azure OpenAI')),
+            identifierLabel: 'Deployment',
+            dimensions: Number(configuration.get('yoink.embedding.azure.dimensions', 1536)),
+            requiresApiKey: true,
+            hasApiKey: hasAzureKey,
+            missingFields: hasAzureKey ? [] : ['API key'],
+            isConfigured: hasAzureKey,
+            fingerprint: 'fp-azure',
+          };
+        }
+        if (provider === 'local') {
+          return {
+            provider,
+            providerLabel: 'Local',
+            identifier: String(configuration.get('yoink.embedding.local.model', 'Local model')),
+            identifierLabel: 'Model',
+            dimensions: Number(configuration.get('yoink.embedding.local.dimensions', 768)),
+            requiresApiKey: false,
+            hasApiKey: hasLocalKey,
+            missingFields: [],
+            isConfigured: true,
+            fingerprint: 'fp-local',
+          };
+        }
+        return {
+          provider,
+          providerLabel: 'OpenAI',
+          identifier: String(configuration.get('yoink.embedding.openai.model', 'text-embedding-3-small')),
+          identifierLabel: 'Model',
+          dimensions: 1536,
+          requiresApiKey: true,
+          hasApiKey: hasOpenAIKey,
+          missingFields: hasOpenAIKey ? [] : ['API key'],
+          isConfigured: hasOpenAIKey,
+          fingerprint: 'fp-openai',
+        };
+      }),
+      setApiKey: vi.fn(async () => { hasOpenAIKey = true; }),
+      setAzureApiKey: vi.fn(async () => { hasAzureKey = true; }),
+      setLocalApiKey: vi.fn(async () => { hasLocalKey = true; }),
+      clearLocalApiKey: vi.fn(async () => { hasLocalKey = false; }),
+    };
+
+    embeddingStore = {
+      countAll: vi.fn().mockReturnValue(4),
+      refreshAfterSchemaChange: vi.fn(),
+    };
+    getDataSources = vi.fn().mockReturnValue([{ id: 'ds-1' }, { id: 'ds-2' }]);
+    queueReindexAll = vi.fn().mockResolvedValue(undefined);
+    getEmbeddingConfigFingerprint.mockReturnValue('fp-openai');
+    getEmbeddingDimensions.mockReturnValue(1536);
+  });
+
+  it('manages Azure embeddings and triggers a rebuild', async () => {
+    showQuickPick
+      .mockResolvedValueOnce({
+        label: 'Azure OpenAI',
+        description: 'Azure OpenAI deployment',
+        provider: 'azure-openai',
+      });
+    showInputBox
+      .mockResolvedValueOnce('https://myresource.openai.azure.com')
+      .mockResolvedValueOnce('prod-embed')
+      .mockResolvedValueOnce('2024-02-01')
+      .mockResolvedValueOnce('3072')
+      .mockResolvedValueOnce('azure-secret');
+
+    const manager = new EmbeddingManager(
+      registry,
+      {} as any,
+      embeddingStore,
+      getDataSources,
+      queueReindexAll,
+    );
+
+    await manager.manageEmbeddings();
+
+    expect(configuration.update).toHaveBeenCalledWith('yoink.embedding.provider', 'azure-openai', 1);
+    expect(configuration.update).toHaveBeenCalledWith(
+      'yoink.embedding.azure.endpoint',
+      'https://myresource.openai.azure.com',
+      1,
+    );
+    expect(configuration.update).toHaveBeenCalledWith('yoink.embedding.azure.deploymentName', 'prod-embed', 1);
+    expect(configuration.update).toHaveBeenCalledWith('yoink.embedding.azure.apiVersion', '2024-02-01', 1);
+    expect(configuration.update).toHaveBeenCalledWith('yoink.embedding.azure.dimensions', 3072, 1);
+    expect(registry.setAzureApiKey).toHaveBeenCalledWith('azure-secret');
+    expect(resetEmbeddingsTable).toHaveBeenCalledWith(expect.anything(), 3072);
+    expect(setEmbeddingConfigFingerprint).toHaveBeenCalledWith(expect.anything(), 'fp-azure');
+    expect(queueReindexAll).toHaveBeenCalled();
+  });
+
+  it('prompts to rebuild on startup when settings drift is detected', async () => {
+    getConfigValues().set('yoink.embedding.provider', 'azure-openai');
+    hasAzureKey = true;
+    getEmbeddingConfigFingerprint.mockReturnValue('fp-openai');
+    getEmbeddingDimensions.mockReturnValue(1536);
+    showInformationMessage.mockResolvedValue('Rebuild');
+
+    const manager = new EmbeddingManager(
+      registry,
+      {} as any,
+      embeddingStore,
+      getDataSources,
+      queueReindexAll,
+    );
+
+    await manager.initialize();
+
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      'Yoink: Embedding settings changed via startup. Rebuild embeddings now?',
+      'Rebuild',
+      'Later',
+    );
+    expect(resetEmbeddingsTable).toHaveBeenCalledWith(expect.anything(), 3072);
+    expect(queueReindexAll).toHaveBeenCalled();
+  });
+
+  it('reports stale status when the stored fingerprint no longer matches', async () => {
+    getConfigValues().set('yoink.embedding.provider', 'azure-openai');
+    hasAzureKey = true;
+    getEmbeddingConfigFingerprint.mockReturnValue('fp-openai');
+    getEmbeddingDimensions.mockReturnValue(1536);
+
+    const manager = new EmbeddingManager(
+      registry,
+      {} as any,
+      embeddingStore,
+      getDataSources,
+      queueReindexAll,
+    );
+
+    const status = await manager.getStatus();
+
+    expect(status.isStale).toBe(true);
+    expect(status.actionCommand).toBe('yoink.rebuildEmbeddings');
+    expect(status.statusLabel).toBe('Rebuild required');
+  });
+});

--- a/test/unit/sources/dataSourceManager.test.ts
+++ b/test/unit/sources/dataSourceManager.test.ts
@@ -30,7 +30,7 @@ describe('DataSourceManager', () => {
   let dataSources: DataSourceConfig[];
   let configManager: any;
   let pipeline: any;
-  let embeddingRegistry: any;
+  let embeddingManager: any;
   let manager: DataSourceManager;
 
   beforeEach(() => {
@@ -49,11 +49,10 @@ describe('DataSourceManager', () => {
       enqueue: vi.fn(),
       removeDataSource: vi.fn(),
     };
-    embeddingRegistry = {
-      getProvider: vi.fn().mockResolvedValue({}),
-      hasApiKey: vi.fn().mockResolvedValue(true),
+    embeddingManager = {
+      ensureConfigured: vi.fn().mockResolvedValue(true),
     };
-    manager = new DataSourceManager(configManager, pipeline, embeddingRegistry);
+    manager = new DataSourceManager(configManager, pipeline, embeddingManager);
   });
 
   it('add creates a data source and enqueues it', async () => {

--- a/test/unit/ui/addRepoWizard.test.ts
+++ b/test/unit/ui/addRepoWizard.test.ts
@@ -25,7 +25,7 @@ describe('AddRepoWizard', () => {
   let resolver: any;
   let browser: any;
   let dataSourceManager: any;
-  let embeddingRegistry: any;
+  let embeddingManager: any;
 
   const metadata = {
     owner: 'acme',
@@ -49,10 +49,8 @@ describe('AddRepoWizard', () => {
       add: vi.fn().mockResolvedValue({ id: 'ds-1' }),
       isDuplicate: vi.fn().mockReturnValue(false),
     };
-    embeddingRegistry = {
-      hasApiKey: vi.fn().mockResolvedValue(true),
-      setApiKey: vi.fn(),
-      getProvider: vi.fn(),
+    embeddingManager = {
+      ensureConfigured: vi.fn().mockResolvedValue(true),
     };
   });
 
@@ -79,7 +77,7 @@ describe('AddRepoWizard', () => {
 
   it('completes the full wizard flow', async () => {
     setupFullFlow();
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingManager);
 
     await wizard.run();
 
@@ -115,7 +113,7 @@ describe('AddRepoWizard', () => {
       .mockResolvedValueOnce('main')
       .mockImplementationOnce(async (opts: any) => opts.value); // accept pre-filled include value
 
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingManager);
     await wizard.run();
 
     expect(dataSourceManager.add).toHaveBeenCalledWith(
@@ -132,7 +130,7 @@ describe('AddRepoWizard', () => {
     });
     (vscode.window.showInputBox as any).mockResolvedValueOnce(undefined);
 
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingManager);
     await wizard.run();
 
     expect(dataSourceManager.add).not.toHaveBeenCalled();
@@ -148,7 +146,7 @@ describe('AddRepoWizard', () => {
     // Branch cancelled
     (vscode.window.showInputBox as any).mockResolvedValueOnce(undefined);
 
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingManager);
     await wizard.run();
 
     expect(dataSourceManager.add).not.toHaveBeenCalled();
@@ -177,7 +175,7 @@ describe('AddRepoWizard', () => {
       .mockResolvedValueOnce('main')
       .mockResolvedValueOnce('');
 
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingManager);
     await wizard.run();
 
     expect(browser.listAllUserRepos).toHaveBeenCalled();
@@ -195,7 +193,7 @@ describe('AddRepoWizard', () => {
       .mockResolvedValueOnce('main')
       .mockResolvedValueOnce(''); // empty include
 
-    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingRegistry);
+    const wizard = new AddRepoWizard(resolver, browser, dataSourceManager, embeddingManager);
     await wizard.run();
 
     expect(dataSourceManager.add).toHaveBeenCalledWith(

--- a/test/unit/ui/commands.test.ts
+++ b/test/unit/ui/commands.test.ts
@@ -24,6 +24,7 @@ import { DataSourceConfig } from '../../../src/config/configSchema';
 describe('registerCommands', () => {
   let configManager: any;
   let dataSourceManager: any;
+  let embeddingManager: any;
   let providerRegistry: any;
   let wizardFactory: any;
   let context: any;
@@ -48,8 +49,14 @@ describe('registerCommands', () => {
       sync: vi.fn(),
       syncAll: vi.fn(),
     };
+    embeddingManager = {
+      manageEmbeddings: vi.fn(),
+      rebuildEmbeddings: vi.fn(),
+      refresh: vi.fn(),
+    };
     providerRegistry = {
       setApiKey: vi.fn(),
+      setAzureApiKey: vi.fn(),
     };
     wizardFactory = vi.fn().mockReturnValue({ run: vi.fn() });
     workspaceConfigManager = {
@@ -61,7 +68,16 @@ describe('registerCommands', () => {
     };
     context = { subscriptions: { push: vi.fn() } };
 
-    registerCommands(context, configManager, dataSourceManager, providerRegistry, wizardFactory, workspaceConfigManager, agentInstaller);
+    registerCommands(
+      context,
+      configManager,
+      dataSourceManager,
+      embeddingManager,
+      providerRegistry,
+      wizardFactory,
+      workspaceConfigManager,
+      agentInstaller,
+    );
   });
 
   it('registers all expected commands', () => {
@@ -69,6 +85,8 @@ describe('registerCommands', () => {
     expect(commands.has('yoink.removeRepository')).toBe(true);
     expect(commands.has('yoink.syncDataSource')).toBe(true);
     expect(commands.has('yoink.syncAllDataSources')).toBe(true);
+    expect(commands.has('yoink.manageEmbeddings')).toBe(true);
+    expect(commands.has('yoink.rebuildEmbeddings')).toBe(true);
     expect(commands.has('yoink.setApiKey')).toBe(true);
   });
 
@@ -124,6 +142,18 @@ describe('registerCommands', () => {
     await commands.get('yoink.syncAllDataSources')!();
 
     expect(dataSourceManager.syncAll).toHaveBeenCalled();
+  });
+
+  it('manageEmbeddings delegates to the embedding manager', async () => {
+    await commands.get('yoink.manageEmbeddings')!();
+
+    expect(embeddingManager.manageEmbeddings).toHaveBeenCalled();
+  });
+
+  it('rebuildEmbeddings delegates to the embedding manager', async () => {
+    await commands.get('yoink.rebuildEmbeddings')!();
+
+    expect(embeddingManager.rebuildEmbeddings).toHaveBeenCalled();
   });
 
   it('setApiKey saves the key', async () => {

--- a/test/unit/ui/sidebar/sidebar.test.ts
+++ b/test/unit/ui/sidebar/sidebar.test.ts
@@ -38,8 +38,9 @@ import {
   DataSourceTreeItem,
   DataSourceInfoItem,
   DataSourceFileItem,
+  EmbeddingTreeItem,
 } from '../../../../src/ui/sidebar/sidebarTreeItems';
-import { DataSourceTreeProvider } from '../../../../src/ui/sidebar/sidebarProvider';
+import { DataSourceTreeProvider, EmbeddingTreeProvider } from '../../../../src/ui/sidebar/sidebarProvider';
 import { DataSourceConfig } from '../../../../src/config/configSchema';
 
 function makeDs(overrides: Partial<DataSourceConfig> = {}): DataSourceConfig {
@@ -258,3 +259,85 @@ describe('DataSourceTreeProvider', () => {
   });
 });
 
+describe('EmbeddingTreeItem', () => {
+  it('shows configured state', () => {
+    const item = new EmbeddingTreeItem({
+      provider: 'openai',
+      providerLabel: 'OpenAI',
+      identifier: 'text-embedding-3-small',
+      identifierLabel: 'Model',
+      dimensions: 1536,
+      requiresApiKey: true,
+      hasApiKey: true,
+      missingFields: [],
+      isConfigured: true,
+      fingerprint: 'fp-openai',
+      isRebuilding: false,
+      isStale: false,
+      statusLabel: 'Configured',
+      actionCommand: 'yoink.manageEmbeddings',
+      tooltip: 'configured',
+    });
+
+    expect(item.label).toBe('OpenAI: text-embedding-3-small');
+    expect(item.description).toContain('Configured');
+    expect(item.contextValue).toBe('embeddingReady');
+    expect(item.command?.command).toBe('yoink.manageEmbeddings');
+  });
+
+  it('shows stale state as rebuildable', () => {
+    const item = new EmbeddingTreeItem({
+      provider: 'azure-openai',
+      providerLabel: 'Azure OpenAI',
+      identifier: 'embed-prod',
+      identifierLabel: 'Deployment',
+      dimensions: 3072,
+      requiresApiKey: true,
+      hasApiKey: true,
+      missingFields: [],
+      isConfigured: true,
+      fingerprint: 'fp-azure',
+      isRebuilding: false,
+      isStale: true,
+      statusLabel: 'Rebuild required',
+      actionCommand: 'yoink.rebuildEmbeddings',
+      tooltip: 'rebuild required',
+    });
+
+    expect(item.description).toContain('Rebuild required');
+    expect(item.contextValue).toBe('embeddingStale');
+    expect(item.command?.command).toBe('yoink.rebuildEmbeddings');
+  });
+});
+
+describe('EmbeddingTreeProvider', () => {
+  it('returns the embedding status item', async () => {
+    const embeddingManager = {
+      getStatus: vi.fn().mockResolvedValue({
+        provider: 'local',
+        providerLabel: 'Local',
+        identifier: 'nomic-embed-text',
+        identifierLabel: 'Model',
+        dimensions: 768,
+        requiresApiKey: false,
+        hasApiKey: false,
+        missingFields: [],
+        isConfigured: true,
+        fingerprint: 'fp-local',
+        isRebuilding: false,
+        isStale: false,
+        statusLabel: 'Configured',
+        actionCommand: 'yoink.manageEmbeddings',
+        tooltip: 'configured',
+      }),
+      onDidChange: (listener: () => void) => ({ dispose: vi.fn() }),
+    } as any;
+
+    const provider = new EmbeddingTreeProvider(embeddingManager);
+    const children = await provider.getChildren();
+
+    expect(children).toHaveLength(1);
+    expect(children[0]).toBeInstanceOf(EmbeddingTreeItem);
+    expect(children[0].label).toBe('Local: nomic-embed-text');
+  });
+});


### PR DESCRIPTION
## Summary
- add a first-class embedding management flow for OpenAI, Azure OpenAI, and local providers
- expose manage/rebuild actions through the command palette and the embedding sidebar
- detect embedding config drift, mark embeddings as stale, and trigger full rebuilds safely

## Why
Yoink previously only handled initial embedding setup in an OpenAI-specific way and did not offer a way to update provider settings or rebuild embeddings after those settings changed. Azure OpenAI support also existed only partially because the required endpoint, deployment, API version, dimensions, and API key flow were not fully surfaced in the UX.

## Impact
Users can now configure and update embedding providers directly from the extension UI, including full Azure OpenAI setup. Existing indexes are rebuilt when embedding settings change so vector data stays consistent with the active provider configuration.

## Validation
- `npm run build`
- `npm run lint`
- `npx tsc --noEmit`
- `npx vitest run test/unit/embedding/manager.test.ts test/unit/ui/commands.test.ts test/unit/ui/addRepoWizard.test.ts test/unit/sources/dataSourceManager.test.ts test/unit/ui/sidebar/sidebar.test.ts`

## Notes
- SQLite-backed storage tests were not run in this environment because the available `better-sqlite3` binary architecture does not match the current Node architecture.
