### PR TITLE
feat: group data sources by type and signal embedding connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 coverage/
+test-results/
 *.vsix
 .vscode-test/
 .claude/settings.local.json

--- a/package.json
+++ b/package.json
@@ -158,12 +158,12 @@
     "views": {
       "yoink": [
         {
-          "id": "yoink.embedding",
-          "name": "Embedding"
-        },
-        {
           "id": "yoink.dataSources",
           "name": "Data Sources"
+        },
+        {
+          "id": "yoink.embedding",
+          "name": "Embedding"
         }
       ]
     },

--- a/src/embedding/manager.ts
+++ b/src/embedding/manager.ts
@@ -23,12 +23,16 @@ interface EmbeddingAssessment {
   isStale: boolean;
 }
 
+export type EmbeddingConnectionStatus = 'unknown' | 'success' | 'failed';
+
 export interface EmbeddingStatus extends EmbeddingConfigurationState {
   isRebuilding: boolean;
   isStale: boolean;
   statusLabel: string;
   actionCommand: 'yoink.manageEmbeddings' | 'yoink.rebuildEmbeddings';
   tooltip: string;
+  connectionStatus: EmbeddingConnectionStatus;
+  connectionError?: string;
 }
 
 interface ManageEmbeddingResult {
@@ -46,6 +50,9 @@ export class EmbeddingManager implements vscode.Disposable {
   private rebuilding = false;
   private suppressConfigEvents = false;
   private stalePromptKey?: string;
+  private connectionStatus: EmbeddingConnectionStatus = 'unknown';
+  private connectionError?: string;
+  private connectionTestInFlight?: Promise<void>;
 
   constructor(
     private readonly registry: EmbeddingProviderRegistry,
@@ -67,6 +74,39 @@ export class EmbeddingManager implements vscode.Disposable {
 
   async initialize(): Promise<void> {
     await this.handleConfigurationDrift('startup');
+    void this.testConnection();
+  }
+
+  private async testConnection(): Promise<void> {
+    if (this.connectionTestInFlight) {
+      return this.connectionTestInFlight;
+    }
+
+    const run = async (): Promise<void> => {
+      const config = await this.registry.getConfigurationState();
+      if (!config.isConfigured) {
+        this.connectionStatus = 'unknown';
+        this.connectionError = undefined;
+        this.refresh();
+        return;
+      }
+
+      try {
+        const provider = await this.registry.getProvider();
+        await provider.embed(['ping']);
+        this.connectionStatus = 'success';
+        this.connectionError = undefined;
+      } catch (e) {
+        this.connectionStatus = 'failed';
+        this.connectionError = e instanceof Error ? e.message : String(e);
+      }
+      this.refresh();
+    };
+
+    this.connectionTestInFlight = run().finally(() => {
+      this.connectionTestInFlight = undefined;
+    });
+    return this.connectionTestInFlight;
   }
 
   async ensureConfigured(): Promise<boolean> {
@@ -199,6 +239,7 @@ export class EmbeddingManager implements vscode.Disposable {
     } finally {
       this.rebuilding = false;
       this.refresh();
+      void this.testConnection();
     }
   }
 
@@ -233,6 +274,16 @@ export class EmbeddingManager implements vscode.Disposable {
       lines.push('API key: configured');
     }
 
+    if (assessment.config.isConfigured) {
+      if (this.connectionStatus === 'success') {
+        lines.push('Connection: OK');
+      } else if (this.connectionStatus === 'failed') {
+        lines.push(`Connection: failed${this.connectionError ? ` — ${this.connectionError}` : ''}`);
+      } else {
+        lines.push('Connection: not tested');
+      }
+    }
+
     return {
       ...assessment.config,
       isRebuilding: this.rebuilding,
@@ -240,6 +291,8 @@ export class EmbeddingManager implements vscode.Disposable {
       statusLabel,
       actionCommand,
       tooltip: lines.join('\n'),
+      connectionStatus: this.connectionStatus,
+      connectionError: this.connectionError,
     };
   }
 
@@ -257,8 +310,14 @@ export class EmbeddingManager implements vscode.Disposable {
     const assessment = await this.assessState();
 
     if (!assessment.config.isConfigured || !assessment.config.fingerprint) {
+      this.connectionStatus = 'unknown';
+      this.connectionError = undefined;
       this.refresh();
       return;
+    }
+
+    if (source !== 'startup') {
+      void this.testConnection();
     }
 
     if (!assessment.storedFingerprint) {

--- a/src/embedding/manager.ts
+++ b/src/embedding/manager.ts
@@ -53,6 +53,7 @@ export class EmbeddingManager implements vscode.Disposable {
   private connectionStatus: EmbeddingConnectionStatus = 'unknown';
   private connectionError?: string;
   private connectionTestInFlight?: Promise<void>;
+  private connectionTestPending = false;
 
   constructor(
     private readonly registry: EmbeddingProviderRegistry,
@@ -79,6 +80,7 @@ export class EmbeddingManager implements vscode.Disposable {
 
   private async testConnection(): Promise<void> {
     if (this.connectionTestInFlight) {
+      this.connectionTestPending = true;
       return this.connectionTestInFlight;
     }
 
@@ -105,6 +107,10 @@ export class EmbeddingManager implements vscode.Disposable {
 
     this.connectionTestInFlight = run().finally(() => {
       this.connectionTestInFlight = undefined;
+      if (this.connectionTestPending) {
+        this.connectionTestPending = false;
+        void this.testConnection();
+      }
     });
     return this.connectionTestInFlight;
   }

--- a/src/ui/sidebar/sidebarProvider.ts
+++ b/src/ui/sidebar/sidebarProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { ConfigManager } from '../../config/configManager';
 import {
   SidebarTreeItem,
+  DataSourceTypeGroupItem,
   DataSourceTreeItem,
   DataSourceInfoItem,
   DataSourceFileItem,
@@ -11,6 +12,51 @@ import { SETTING_KEYS } from '../../config/settingsSchema';
 import { ChunkStore } from '../../storage/chunkStore';
 import { ProgressTracker } from '../../ingestion/progressTracker';
 import { EmbeddingManager } from '../../embedding/manager';
+import { DataSourceConfig } from '../../config/configSchema';
+import { DataSourceType } from '../../config/repoTypePresets';
+
+const TYPE_GROUP_ORDER: DataSourceType[] = [
+  'documentation',
+  'cicd-workflows',
+  'github-actions-library',
+  'source-code',
+  'general',
+  'openapi-specs',
+];
+
+export function groupDataSourcesByType(
+  sources: readonly DataSourceConfig[],
+): Array<{ type: DataSourceType; sources: DataSourceConfig[] }> {
+  const buckets = new Map<DataSourceType, DataSourceConfig[]>();
+  for (const ds of sources) {
+    const list = buckets.get(ds.type);
+    if (list) {
+      list.push(ds);
+    } else {
+      buckets.set(ds.type, [ds]);
+    }
+  }
+  const groups: Array<{ type: DataSourceType; sources: DataSourceConfig[] }> = [];
+  for (const type of TYPE_GROUP_ORDER) {
+    const list = buckets.get(type);
+    if (list && list.length > 0) {
+      groups.push({ type, sources: sortRepos(list) });
+      buckets.delete(type);
+    }
+  }
+  for (const [type, list] of buckets) {
+    if (list.length > 0) {
+      groups.push({ type, sources: sortRepos(list) });
+    }
+  }
+  return groups;
+}
+
+function sortRepos(list: DataSourceConfig[]): DataSourceConfig[] {
+  return [...list].sort((a, b) =>
+    `${a.owner}/${a.repo}`.localeCompare(`${b.owner}/${b.repo}`),
+  );
+}
 
 export class DataSourceTreeProvider
   implements vscode.TreeDataProvider<SidebarTreeItem>
@@ -37,7 +83,17 @@ export class DataSourceTreeProvider
 
   getChildren(element?: SidebarTreeItem): SidebarTreeItem[] {
     if (!element) {
-      return this.configManager.getDataSources().map(
+      const groups = groupDataSourcesByType(this.configManager.getDataSources());
+      return groups.map(
+        (g) => new DataSourceTypeGroupItem(g.type, g.sources.length),
+      );
+    }
+
+    if (element instanceof DataSourceTypeGroupItem) {
+      const groups = groupDataSourcesByType(this.configManager.getDataSources());
+      const group = groups.find((g) => g.type === element.type);
+      if (!group) return [];
+      return group.sources.map(
         (ds) => new DataSourceTreeItem(
           ds,
           this.progressTracker.get(ds.id),

--- a/src/ui/sidebar/sidebarTreeItems.ts
+++ b/src/ui/sidebar/sidebarTreeItems.ts
@@ -4,8 +4,10 @@ import { DataSourceStats, FileStats } from '../../storage/chunkStore';
 import { IndexingProgress } from '../../ingestion/progressTracker';
 import { getPricingForModel, formatCost } from '../../embedding/pricing';
 import { EmbeddingStatus } from '../../embedding/manager';
+import { DataSourceType, REPO_TYPE_PRESETS } from '../../config/repoTypePresets';
 
 export type SidebarTreeItem =
+  | DataSourceTypeGroupItem
   | DataSourceTreeItem
   | DataSourceInfoItem
   | DataSourceFileItem
@@ -21,6 +23,29 @@ const STATUS_ICONS: Record<string, string> = {
 
 function formatNumber(n: number): string {
   return n.toLocaleString('en-US');
+}
+
+const TYPE_GROUP_ICONS: Record<DataSourceType, string> = {
+  documentation: 'book',
+  'cicd-workflows': 'play-circle',
+  'github-actions-library': 'package',
+  'source-code': 'code',
+  general: 'database',
+  'openapi-specs': 'json',
+};
+
+export class DataSourceTypeGroupItem extends vscode.TreeItem {
+  constructor(
+    public readonly type: DataSourceType,
+    public readonly count: number,
+  ) {
+    const preset = REPO_TYPE_PRESETS[type];
+    super(preset.displayName, vscode.TreeItemCollapsibleState.Expanded);
+    this.description = `${count}`;
+    this.contextValue = 'dataSourceTypeGroup';
+    this.iconPath = new vscode.ThemeIcon(TYPE_GROUP_ICONS[type] ?? 'folder');
+    this.tooltip = `${preset.displayName} · ${count} ${count === 1 ? 'repo' : 'repos'}`;
+  }
 }
 
 export class DataSourceTreeItem extends vscode.TreeItem {
@@ -162,6 +187,16 @@ export class EmbeddingTreeItem extends vscode.TreeItem {
       this.iconPath = new vscode.ThemeIcon(
         'warning',
         new vscode.ThemeColor('problemsWarningIcon.foreground'),
+      );
+    } else if (status.connectionStatus === 'failed') {
+      this.iconPath = new vscode.ThemeIcon(
+        'circle-filled',
+        new vscode.ThemeColor('errorForeground'),
+      );
+    } else if (status.connectionStatus === 'success') {
+      this.iconPath = new vscode.ThemeIcon(
+        'circle-filled',
+        new vscode.ThemeColor('testing.runAction'),
       );
     } else {
       this.iconPath = new vscode.ThemeIcon('symbol-misc');

--- a/src/ui/sidebar/sidebarTreeItems.ts
+++ b/src/ui/sidebar/sidebarTreeItems.ts
@@ -39,13 +39,22 @@ export class DataSourceTypeGroupItem extends vscode.TreeItem {
     public readonly type: DataSourceType,
     public readonly count: number,
   ) {
-    const preset = REPO_TYPE_PRESETS[type];
-    super(preset.displayName, vscode.TreeItemCollapsibleState.Expanded);
+    const displayName = REPO_TYPE_PRESETS[type]?.displayName ?? humanizeType(type);
+    super(displayName, vscode.TreeItemCollapsibleState.Expanded);
     this.description = `${count}`;
     this.contextValue = 'dataSourceTypeGroup';
     this.iconPath = new vscode.ThemeIcon(TYPE_GROUP_ICONS[type] ?? 'folder');
-    this.tooltip = `${preset.displayName} · ${count} ${count === 1 ? 'repo' : 'repos'}`;
+    this.tooltip = `${displayName} · ${count} ${count === 1 ? 'repo' : 'repos'}`;
   }
+}
+
+function humanizeType(type: string): string {
+  if (!type) return 'Unknown';
+  return type
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(' ');
 }
 
 export class DataSourceTreeItem extends vscode.TreeItem {

--- a/test/unit/embedding/manager.test.ts
+++ b/test/unit/embedding/manager.test.ts
@@ -85,6 +85,12 @@ vi.mock('../../../src/storage/database', () => ({
 
 import { EmbeddingManager } from '../../../src/embedding/manager';
 
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe('EmbeddingManager', () => {
   let registry: any;
   let embeddingStore: any;
@@ -252,6 +258,40 @@ describe('EmbeddingManager', () => {
     );
     expect(resetEmbeddingsTable).toHaveBeenCalledWith(expect.anything(), 3072);
     expect(queueReindexAll).toHaveBeenCalled();
+  });
+
+  it('runs a follow-up connection probe when one was requested while in-flight', async () => {
+    let pendingResolve: ((v: number[][]) => void) | undefined;
+    const embed = vi.fn().mockImplementation(() => new Promise<number[][]>((resolve) => {
+      pendingResolve = resolve;
+    }));
+    registry.getProvider = vi.fn().mockResolvedValue({ embed });
+
+    const manager = new EmbeddingManager(
+      registry,
+      {} as any,
+      embeddingStore,
+      getDataSources,
+      queueReindexAll,
+    );
+
+    const first = (manager as any).testConnection() as Promise<void>;
+    await flushMicrotasks();
+    expect(embed).toHaveBeenCalledTimes(1);
+
+    const queued = (manager as any).testConnection() as Promise<void>;
+    await flushMicrotasks();
+    expect(embed).toHaveBeenCalledTimes(1);
+
+    pendingResolve?.([[1]]);
+    await first;
+    await queued;
+    await flushMicrotasks();
+    expect(embed).toHaveBeenCalledTimes(2);
+
+    pendingResolve?.([[1]]);
+    await flushMicrotasks();
+    expect(embed).toHaveBeenCalledTimes(2);
   });
 
   it('reports stale status when the stored fingerprint no longer matches', async () => {

--- a/test/unit/ui/sidebar/sidebar.test.ts
+++ b/test/unit/ui/sidebar/sidebar.test.ts
@@ -35,17 +35,23 @@ vi.mock('vscode', () => ({
 }));
 
 import {
+  DataSourceTypeGroupItem,
   DataSourceTreeItem,
   DataSourceInfoItem,
   DataSourceFileItem,
   EmbeddingTreeItem,
 } from '../../../../src/ui/sidebar/sidebarTreeItems';
-import { DataSourceTreeProvider, EmbeddingTreeProvider } from '../../../../src/ui/sidebar/sidebarProvider';
+import {
+  DataSourceTreeProvider,
+  EmbeddingTreeProvider,
+  groupDataSourcesByType,
+} from '../../../../src/ui/sidebar/sidebarProvider';
 import { DataSourceConfig } from '../../../../src/config/configSchema';
 
 function makeDs(overrides: Partial<DataSourceConfig> = {}): DataSourceConfig {
   return {
     id: 'ds-1', repoUrl: '', owner: 'acme', repo: 'widgets', branch: 'main',
+    type: 'documentation',
     includePatterns: [], excludePatterns: [], syncSchedule: 'manual',
     lastSyncedAt: null, lastSyncCommitSha: null, status: 'ready',
     ...overrides,
@@ -201,6 +207,36 @@ describe('DataSourceFileItem', () => {
 });
 
 
+describe('groupDataSourcesByType', () => {
+  it('orders preset types in the canonical order and drops empty ones', () => {
+    const result = groupDataSourcesByType([
+      makeDs({ id: '1', type: 'general' }),
+      makeDs({ id: '2', type: 'documentation' }),
+      makeDs({ id: '3', type: 'github-actions-library' }),
+      makeDs({ id: '4', type: 'cicd-workflows' }),
+    ]);
+
+    expect(result.map((g) => g.type)).toEqual([
+      'documentation',
+      'cicd-workflows',
+      'github-actions-library',
+      'general',
+    ]);
+  });
+
+  it('sorts repos within a group alphabetically by owner/repo', () => {
+    const result = groupDataSourcesByType([
+      makeDs({ id: '1', type: 'documentation', owner: 'z', repo: 'z' }),
+      makeDs({ id: '2', type: 'documentation', owner: 'a', repo: 'a' }),
+      makeDs({ id: '3', type: 'documentation', owner: 'a', repo: 'b' }),
+    ]);
+
+    expect(result[0].sources.map((d) => `${d.owner}/${d.repo}`)).toEqual([
+      'a/a', 'a/b', 'z/z',
+    ]);
+  });
+});
+
 describe('DataSourceTreeProvider', () => {
   function makeChunkStore(stats = { fileCount: 0, chunkCount: 0, totalTokens: 0 }, fileStats: any[] = []) {
     return {
@@ -216,19 +252,58 @@ describe('DataSourceTreeProvider', () => {
     } as any;
   }
 
-  it('returns data source tree items from config at root', () => {
+  it('returns type-group items at root, ordered docs/workflows/actions first', () => {
     const changeCallbacks: Array<() => void> = [];
     const configManager = {
-      getDataSources: () => [makeDs(), makeDs({ id: 'ds-2', owner: 'other', repo: 'lib' })],
+      getDataSources: () => [
+        makeDs({ id: 'ds-actions', type: 'github-actions-library', repo: 'actions' }),
+        makeDs({ id: 'ds-docs', type: 'documentation', repo: 'docs' }),
+        makeDs({ id: 'ds-cicd', type: 'cicd-workflows', repo: 'pipelines' }),
+      ],
       onDidChange: (cb: () => void) => { changeCallbacks.push(cb); return { dispose: vi.fn() }; },
     } as any;
 
     const provider = new DataSourceTreeProvider(configManager, makeChunkStore(), makeProgressTracker());
     const children = provider.getChildren();
 
+    expect(children).toHaveLength(3);
+    expect(children[0]).toBeInstanceOf(DataSourceTypeGroupItem);
+    expect((children[0] as DataSourceTypeGroupItem).type).toBe('documentation');
+    expect((children[1] as DataSourceTypeGroupItem).type).toBe('cicd-workflows');
+    expect((children[2] as DataSourceTypeGroupItem).type).toBe('github-actions-library');
+  });
+
+  it('omits type groups that have no data sources', () => {
+    const configManager = {
+      getDataSources: () => [makeDs({ type: 'documentation' })],
+      onDidChange: () => ({ dispose: vi.fn() }),
+    } as any;
+
+    const provider = new DataSourceTreeProvider(configManager, makeChunkStore(), makeProgressTracker());
+    const children = provider.getChildren();
+
+    expect(children).toHaveLength(1);
+    expect((children[0] as DataSourceTypeGroupItem).type).toBe('documentation');
+    expect(children[0].description).toBe('1');
+  });
+
+  it('expands a type-group node into its data sources', () => {
+    const configManager = {
+      getDataSources: () => [
+        makeDs({ id: 'ds-1', type: 'documentation', owner: 'b', repo: 'beta' }),
+        makeDs({ id: 'ds-2', type: 'documentation', owner: 'a', repo: 'alpha' }),
+        makeDs({ id: 'ds-other', type: 'cicd-workflows', repo: 'wf' }),
+      ],
+      onDidChange: () => ({ dispose: vi.fn() }),
+    } as any;
+
+    const provider = new DataSourceTreeProvider(configManager, makeChunkStore(), makeProgressTracker());
+    const group = new DataSourceTypeGroupItem('documentation', 2);
+    const children = provider.getChildren(group);
+
     expect(children).toHaveLength(2);
-    expect(children[0].label).toBe('acme/widgets');
-    expect(children[1].label).toBe('other/lib');
+    expect(children[0].label).toBe('a/alpha');
+    expect(children[1].label).toBe('b/beta');
   });
 
   it('returns info and file items when expanding a ready data source', () => {
@@ -311,7 +386,7 @@ describe('DataSourceTreeProvider', () => {
 });
 
 describe('EmbeddingTreeItem', () => {
-  it('shows configured state', () => {
+  it('shows configured state with green icon when connection succeeded', () => {
     const item = new EmbeddingTreeItem({
       provider: 'openai',
       providerLabel: 'OpenAI',
@@ -328,12 +403,63 @@ describe('EmbeddingTreeItem', () => {
       statusLabel: 'Configured',
       actionCommand: 'yoink.manageEmbeddings',
       tooltip: 'configured',
+      connectionStatus: 'success',
     });
 
     expect(item.label).toBe('OpenAI: text-embedding-3-small');
     expect(item.description).toContain('Configured');
     expect(item.contextValue).toBe('embeddingReady');
     expect(item.command?.command).toBe('yoink.manageEmbeddings');
+    expect((item.iconPath as any).id).toBe('circle-filled');
+    expect((item.iconPath as any).color?.id).toBe('testing.runAction');
+  });
+
+  it('shows red circle when connection test failed', () => {
+    const item = new EmbeddingTreeItem({
+      provider: 'openai',
+      providerLabel: 'OpenAI',
+      identifier: 'text-embedding-3-small',
+      identifierLabel: 'Model',
+      dimensions: 1536,
+      requiresApiKey: true,
+      hasApiKey: true,
+      missingFields: [],
+      isConfigured: true,
+      fingerprint: 'fp-openai',
+      isRebuilding: false,
+      isStale: false,
+      statusLabel: 'Configured',
+      actionCommand: 'yoink.manageEmbeddings',
+      tooltip: 'configured',
+      connectionStatus: 'failed',
+      connectionError: 'auth failed',
+    });
+
+    expect((item.iconPath as any).id).toBe('circle-filled');
+    expect((item.iconPath as any).color?.id).toBe('errorForeground');
+  });
+
+  it('falls back to neutral icon when connection status is unknown', () => {
+    const item = new EmbeddingTreeItem({
+      provider: 'local',
+      providerLabel: 'Local',
+      identifier: 'nomic-embed-text',
+      identifierLabel: 'Model',
+      dimensions: 768,
+      requiresApiKey: false,
+      hasApiKey: false,
+      missingFields: [],
+      isConfigured: true,
+      fingerprint: 'fp-local',
+      isRebuilding: false,
+      isStale: false,
+      statusLabel: 'Configured',
+      actionCommand: 'yoink.manageEmbeddings',
+      tooltip: 'configured',
+      connectionStatus: 'unknown',
+    });
+
+    expect((item.iconPath as any).id).toBe('symbol-misc');
   });
 
   it('shows stale state as rebuildable', () => {
@@ -353,11 +479,13 @@ describe('EmbeddingTreeItem', () => {
       statusLabel: 'Rebuild required',
       actionCommand: 'yoink.rebuildEmbeddings',
       tooltip: 'rebuild required',
+      connectionStatus: 'success',
     });
 
     expect(item.description).toContain('Rebuild required');
     expect(item.contextValue).toBe('embeddingStale');
     expect(item.command?.command).toBe('yoink.rebuildEmbeddings');
+    expect((item.iconPath as any).id).toBe('warning');
   });
 });
 
@@ -380,6 +508,7 @@ describe('EmbeddingTreeProvider', () => {
         statusLabel: 'Configured',
         actionCommand: 'yoink.manageEmbeddings',
         tooltip: 'configured',
+        connectionStatus: 'success',
       }),
       onDidChange: (listener: () => void) => ({ dispose: vi.fn() }),
     } as any;

--- a/test/unit/ui/sidebar/sidebar.test.ts
+++ b/test/unit/ui/sidebar/sidebar.test.ts
@@ -207,6 +207,22 @@ describe('DataSourceFileItem', () => {
 });
 
 
+describe('DataSourceTypeGroupItem', () => {
+  it('renders an unknown repo type without crashing', () => {
+    const item = new DataSourceTypeGroupItem('made-up-type' as any, 2);
+    expect(item.label).toBe('Made Up Type');
+    expect(item.description).toBe('2');
+    expect((item.iconPath as any).id).toBe('folder');
+    expect(item.tooltip).toContain('Made Up Type');
+  });
+
+  it('uses preset displayName for known types', () => {
+    const item = new DataSourceTypeGroupItem('documentation', 1);
+    expect(item.label).toBe('Documentation / standards');
+    expect(item.description).toBe('1');
+  });
+});
+
 describe('groupDataSourcesByType', () => {
   it('orders preset types in the canonical order and drops empty ones', () => {
     const result = groupDataSourcesByType([


### PR DESCRIPTION
- Reorder sidebar so Data Sources sits above Embedding.
- Group data sources under one expandable node per repo type
  (documentation, cicd-workflows, github-actions-library first),
  hiding empty groups.
- Run a one-shot embed('ping') on activation and on settings change
  and surface the result as a green/red filled circle on the
  embedding tree item.